### PR TITLE
Fix cron package collision if its declared somewhere outside

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -30,8 +30,11 @@ class zookeeper::install(
 
   # if !$cleanup_count, then ensure this cron is absent.
   if ($snap_retain_count > 0 and $ensure != 'absent') {
-    ensure_packages(['cron'])
-
+    
+    ensure_resource('package', 'cron', {
+      ensure => 'installed',
+    })
+    
     cron { 'zookeeper-cleanup':
         ensure  => present,
         command => "${cleanup_sh} ${datastore} ${snap_retain_count}",


### PR DESCRIPTION
Duplicate declaration: Package[cron] is already declared in file /etc/puppet/modules/profile/profile_minimal/manifests/cron.pp:13; cannot redeclare at /etc/puppet/modules/forge/zookeeper/manifests/install.pp:33
