### PR TITLE
Provide options to override service name and initialize the datastore.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,6 +22,7 @@
 class zookeeper::config(
   $id                      = '1',
   $datastore               = '/var/lib/zookeeper',
+  $initialize_datastore    = false,
   $client_ip               = $::ipaddress,
   $client_port             = 2181,
   $election_port           = 2888,
@@ -119,5 +120,15 @@ class zookeeper::config(
     client_ip     => $client_ip,
     election_port => $election_port,
     leader_port   => $leader_port,
+  }
+
+  # Initialize the datastore if required
+  if $initialize_datastore {
+    exec { "initialize_datastore":
+      command => "/usr/bin/zookeeper-server-initialize --myid=$id",
+      user    => $user,
+      creates => "$datastore/myid",
+      require => File[$datastore],
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@
 class zookeeper(
   $id                      = '1',
   $datastore               = '/var/lib/zookeeper',
+  $initialize_datastore    = false,
   # fact from which we get public ip address
   $client_ip               = $::ipaddress,
   $client_port             = 2181,
@@ -46,6 +47,7 @@ class zookeeper(
   $start_with              = 'init.d',
   $ensure_cron             = true,
   $service_package         = 'zookeeperd',
+  $service_name            = 'zookeeper',
   $packages                = ['zookeeper']
 ) {
 
@@ -67,6 +69,7 @@ class zookeeper(
   class { 'zookeeper::config':
     id                      => $id,
     datastore               => $datastore,
+    initialize_datastore    => $initialize_datastore,
     client_ip               => $client_ip,
     client_port             => $client_port,
     election_port           => $election_port,
@@ -90,7 +93,8 @@ class zookeeper(
     peer_type               => $peer_type,
   }->
   class { 'zookeeper::service':
-    cfg_dir => $cfg_dir,
+    cfg_dir      => $cfg_dir,
+    service_name => $service_name,
   }
   ->
   anchor { 'zookeeper::end': }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,10 +2,12 @@
 
 class zookeeper::service(
   $cfg_dir = '/etc/zookeeper/conf',
+  $service_name = 'zookeeper',
 ){
   require zookeeper::install
 
   service { 'zookeeper':
+    name       => "$service_name",
     ensure     => 'running',
     hasstatus  => true,
     hasrestart => true,


### PR DESCRIPTION
When using the cloudera packages on CentOS 6 (http://www.cloudera.com/content/cloudera/en/documentation/cdh4/latest/CDH4-Installation-Guide/cdh4ig_topic_21_3.html) it is necessary to override the service name as the init script that is provided with the `zookeeper-server` package is called `zookeeper-server` rather than the expected service name of `zookeeper` that is hardcoded into this module.

Additionally, I have created an `intialize_datastore` parameter which if set to `true` will execute `/usr/bin/zookeeper-server-initialize --myid=$id` and then allow the service to start.
