### PR TITLE
Make servers default value an empty array

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,7 +32,7 @@ class zookeeper(
   $zoo_main                = 'org.apache.zookeeper.server.quorum.QuorumPeerMain',
   $log4j_prop               = 'INFO,ROLLINGFILE',
   $cleanup_sh              = '/usr/share/zookeeper/bin/zkCleanup.sh',
-  $servers                 = [''],
+  $servers                 = [],
   $ensure                  = present,
   $snap_count              = 10000,
   # since zookeeper 3.4, for earlier version cron task might be used


### PR DESCRIPTION
Make the default value an empty array, otherwise if nothing is set for $servers, when the zoo.cfg.erb gets provisioned you end up with 

server.1=

Which results in zookeeper not starting up correctly.
It should only render out the server list in the template if we have actually supplied any servers
