### PR TITLE
Fix issues with future parser in puppet 3.7+

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -24,7 +24,7 @@ class zookeeper::install(
   anchor { 'zookeeper::install::end': }
 
   case $::osfamily {
-    Debian: {
+    'Debian': {
       class { 'zookeeper::os::debian':
         ensure            => $ensure,
         snap_retain_count => $snap_retain_count,
@@ -39,7 +39,7 @@ class zookeeper::install(
         require           => Anchor['zookeeper::install::begin'],
       }
     }
-    RedHat: {
+    'RedHat': {
       class { 'zookeeper::os::redhat':
         ensure            => $ensure,
         snap_retain_count => $snap_retain_count,


### PR DESCRIPTION
When provisioning on Centos 65 , Puppet 3.7 I receive the following error - 

Module 'zookeeper' is not supported on OS: 'CentOS', family: 'RedHat'

Quoting the osfamily seems to solve this