### PR TITLE
Java requirement

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,8 @@ class zookeeper(
   $service_name            = 'zookeeper',
   $packages                = ['zookeeper'],
   $repo                    = undef,
+  $install_java            = false,
+  $java_package            = undef
 ) {
 
   validate_array($packages)
@@ -67,6 +69,8 @@ class zookeeper(
     service_package   => $service_package,
     packages          => $packages,
     repo_source       => $repo,
+    install_java      => $install_java,
+    java_package      => $java_package
   }->
   class { 'zookeeper::config':
     id                      => $id,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -40,8 +40,6 @@ class zookeeper::install(
         packages          => $packages,
         before            => Anchor['zookeeper::install::end'],
         require           => Anchor['zookeeper::install::begin'],
-        install_java      => $install_java,
-        java_package      => $java_package
       }
     }
     'RedHat': {
@@ -60,6 +58,8 @@ class zookeeper::install(
         packages          => $packages,
         require           => Anchor['zookeeper::install::begin'],
         before            => Anchor['zookeeper::install::end'],
+        install_java      => $install_java,
+        java_package      => $java_package
       }
     }
     default: {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,6 +20,8 @@ class zookeeper::install(
   $service_package   = 'zookeeperd',
   $packages          = ['zookeeper'],
   $repo_source       = undef,
+  $install_java      = false,
+  $java_package      = undef
 ) {
   anchor { 'zookeeper::install::begin': }
   anchor { 'zookeeper::install::end': }
@@ -38,6 +40,8 @@ class zookeeper::install(
         packages          => $packages,
         before            => Anchor['zookeeper::install::end'],
         require           => Anchor['zookeeper::install::begin'],
+        install_java      => $install_java,
+        java_package      => $java_package
       }
     }
     'RedHat': {

--- a/manifests/os/redhat.pp
+++ b/manifests/os/redhat.pp
@@ -20,6 +20,12 @@ class zookeeper::os::redhat(
 
   # if $install_java, try to make sure a JDK package is installed
   if ($install_java){
+    if !$java_package {
+      fail { "Java installation is required, but no java package was provided.": }
+    }
+
+    validate_string($java_package)
+
     package{ $java_package:
       ensure => present,
       allow_virtual => true

--- a/manifests/os/redhat.pp
+++ b/manifests/os/redhat.pp
@@ -8,12 +8,23 @@ class zookeeper::os::redhat(
   $user              = 'zookeeper',
   $ensure_cron       = true,
   $packages          = ['zookeeper'],
-  $manual_clean      = false
+  $manual_clean      = false,
+  $install_java      = false,
+  $java_package      = undef
 ) {
+
+  validate_bool($install_java)
 
   # allow installing multiple packages, like zookeeper, zookeeper-bin etc.
   ensure_resource('package', $packages, {'ensure' => $ensure})
 
+  # if $install_java, try to make sure a JDK package is installed
+  if ($install_java){
+    package{ $java_package:
+      ensure => present,
+      allow_virtual => true
+    }
+  }
 
   # if !$cleanup_count, then ensure this cron is absent.
   if ($manual_clean and $snap_retain_count > 0 and $ensure != 'absent') {

--- a/manifests/os/redhat.pp
+++ b/manifests/os/redhat.pp
@@ -15,9 +15,6 @@ class zookeeper::os::redhat(
 
   validate_bool($install_java)
 
-  # allow installing multiple packages, like zookeeper, zookeeper-bin etc.
-  ensure_resource('package', $packages, {'ensure' => $ensure})
-
   # if $install_java, try to make sure a JDK package is installed
   if ($install_java){
     if !$java_package {
@@ -27,10 +24,17 @@ class zookeeper::os::redhat(
     validate_string($java_package)
 
     package{ $java_package:
-      ensure => present,
+      ensure        => present,
       allow_virtual => true
+      before        => Anchor['zookeeper::install::package::begin'],
     }
   }
+
+  anchor { 'zookeeper::install::package::begin': }->
+  package { $packages:
+    ensure => present
+  }->
+  anchor { 'zookeeper::install::package::end': }
 
   # if !$cleanup_count, then ensure this cron is absent.
   if ($manual_clean and $snap_retain_count > 0 and $ensure != 'absent') {

--- a/manifests/os/redhat.pp
+++ b/manifests/os/redhat.pp
@@ -25,7 +25,7 @@ class zookeeper::os::redhat(
 
     package{ $java_package:
       ensure        => present,
-      allow_virtual => true
+      allow_virtual => true,
       before        => Anchor['zookeeper::install::package::begin'],
     }
   }


### PR DESCRIPTION
I found when installing zookeeper that some systems did not have Java installed already, so I added the ability to set a flag to require a Java package be installed, along with a variable to set the name of the Java package.  This was only done for RHEL systems so far since I don't have access to a Debian one right now to test on, but it should be easy enough to potentially just copy the same code from redhat.pp to debian.pp to get it working.