### PR TITLE
Support attribute clientPortAddress in zoo.cfg

### DIFF
--- a/templates/conf/zoo.cfg.erb
+++ b/templates/conf/zoo.cfg.erb
@@ -15,6 +15,7 @@ dataDir=<%= @datastore %>
 
 # the port at which the clients will connect
 clientPort=<%= @client_port %>
+clientPortAddress=<% @client_ip %>
 
 # specify all zookeeper servers
 # The fist port is used by followers to connect to the leader


### PR DESCRIPTION
add support for attribute to clientPortAddress to zoo.cfg to enable binding to specific network interfaces