### PR TITLE
Fixed missing ports in server line of zoo.cfg.erb

### DIFF
--- a/templates/conf/zoo.cfg.erb
+++ b/templates/conf/zoo.cfg.erb
@@ -25,7 +25,7 @@ clientPortAddress=<%= @client_ip %>
 #server.3=zookeeper3:2888:3888
 <% i = 1 -%>
 <% @servers.each do |h| -%>
-<%= "server.#{i}=#{h}" %><% i += 1 %>
+<%= "server.#{i}=#{h}:%s:%s" % [ @election_port, @leader_port ] %><% i += 1 %>
 <% end -%>
 
 # To avoid seeks ZooKeeper allocates space in the transaction log file in


### PR DESCRIPTION
I encountered issues with format of zoo.cfg file in cluster deployment. I fixed it by slightly changing the template.
Please promote the change if you find it useful.

Best regards,
Virgil