### PR TITLE
Add support for declaring observers in the zookeeper cluster

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,6 +39,7 @@ class zookeeper::config(
   $zoo_main                = 'org.apache.zookeeper.server.quorum.QuorumPeerMain',
   $log4j_prop              = 'INFO,ROLLINGFILE',
   $servers                 = [''],
+  $observers               = [''],
   # since zookeeper 3.4, for earlier version cron task might be used
   $snap_retain_count       = 3,
   # interval in hours, purging enabled when >= 1

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,7 @@ class zookeeper(
   $log4j_prop               = 'INFO,ROLLINGFILE',
   $cleanup_sh              = '/usr/share/zookeeper/bin/zkCleanup.sh',
   $servers                 = [],
+  $observers               = [],
   $ensure                  = present,
   $snap_count              = 10000,
   # since zookeeper 3.4, for earlier version cron task might be used
@@ -90,6 +91,7 @@ class zookeeper(
     zoo_main                => $zoo_main,
     log4j_prop              => $log4j_prop,
     servers                 => $servers,
+    observers               => $observers,
     snap_count              => $snap_count,
     snap_retain_count       => $snap_retain_count,
     purge_interval          => $purge_interval,

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -132,6 +132,17 @@ describe 'zookeeper::config', :type => :class do
         should contain_file('/etc/zookeeper/conf/zoo.cfg').with_content(/leaderServes=no/)
       }
     end
+
+    context 'set peer_type to observer' do
+      let(:params){{
+        :peer_type => 'observer'
+      }}
+
+      it { should contain_file(
+        '/etc/zookeeper/conf/zoo.cfg'
+      ).with_content(/peerType=observer/) }
+    end
+
   end
 
   context 'on debian-like system' do
@@ -202,6 +213,45 @@ describe 'zookeeper::config', :type => :class do
     it { should contain_file(
       '/etc/zookeeper/conf/zoo.cfg'
     ).with_content(/server.2=192.168.1.2:2888:3888/) }
+  end
+
+  context 'setting quorum of servers with default ports with observer' do
+    let(:params) {{
+      :servers => ['192.168.1.1', '192.168.1.2', '192.168.1.3', '192.168.1.4', '192.168.1.5'],
+      :observers => ['192.168.1.4', '192.168.1.5']
+    }}
+
+    it { should contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).with_content(/server.1=192.168.1.1:2888:3888/) }
+
+    it { should_not contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).with_content(/server.1=192.168.1.1:2888:3888:observer/) }
+
+    it { should contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).with_content(/server.2=192.168.1.2:2888:3888/) }
+
+    it { should_not contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).with_content(/server.2=192.168.1.2:2888:3888:observer/) }
+
+    it { should contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).with_content(/server.3=192.168.1.3:2888:3888/) }
+
+    it { should_not contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).with_content(/server.3=192.168.1.3:2888:3888:observer/) }
+
+    it { should contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).with_content(/server.4=192.168.1.4:2888:3888:observer/) }
+
+    it { should contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).with_content(/server.5=192.168.1.5:2888:3888:observer/) }
   end
 
 end

--- a/templates/conf/zoo.cfg.erb
+++ b/templates/conf/zoo.cfg.erb
@@ -25,7 +25,10 @@ clientPortAddress=<%= @client_ip %>
 #server.3=zookeeper3:2888:3888
 <% i = 1 -%>
 <% @servers.each_with_index do |h, i| -%>
-<%= "server.#{i+1}=#{h}:%s:%s" % [ @election_port, @leader_port ] %>
+<% if @observers.include? h -%>
+<% observer_text=':observer' -%>
+<% end -%>
+<%= "server.#{i+1}=#{h}:%s:%s%s" % [ @election_port, @leader_port, observer_text ] %>
 <% end -%>
 
 # To avoid seeks ZooKeeper allocates space in the transaction log file in


### PR DESCRIPTION
All servers need to know which nodes are observers in order to construct
quorums correctly.

Signed-off-by: Konrad Scherer <Konrad.Scherer@windriver.com>