### PR TITLE
Adding datalogstore param for dataLogDir to split transaction logs onto different directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ This is a workaround for a a [Facter issue](https://tickets.puppetlabs.com/brows
 
    - `id` - cluster-unique zookeeper's instance id (1-255)
    - `datastore`
+   - `datalogstore` - specifying this configures the dataLogDir Zookeeper config values and allows for transaction logs to be stored in a different location, improving IO performance
    - `log_dir`
    - `purge_interval` - automatically will delete zookeeper logs (available since 3.4.0)
    - `snap_retain_count` - number of snapshots that will be kept after purging (since 3.4.0)
@@ -113,6 +114,7 @@ All parameters could be defined in hiera files, e.g. `common.yaml`, `Debian.yaml
 zookeeper::id: 1
 zookeeper::client_port: 2181
 zookeeper::datastore: '/var/lib/zookeeper'
+zookeeper::datalogstore: '/disk2/zookeeper'
 ```
 
 ## Cloudera package

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,6 +22,7 @@
 class zookeeper::config(
   $id                      = '1',
   $datastore               = '/var/lib/zookeeper',
+  $datalogstore            = undef,
   $initialize_datastore    = false,
   $client_ip               = $::ipaddress,
   $client_port             = 2181,
@@ -79,6 +80,16 @@ class zookeeper::config(
     group   => $group,
     mode    => '0644',
     recurse => true,
+  }
+
+  if $datalogstore {
+    file { $datalogstore:
+      ensure  => directory,
+      owner   => $user,
+      group   => $group,
+      mode    => '0644',
+      recurse => true,
+    }
   }
 
   file { "${cfg_dir}/myid":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,8 @@
 class zookeeper(
   $id                      = '1',
   $datastore               = '/var/lib/zookeeper',
+  # datalogstore used to put transaction logs in separate location than snapshots
+  $datalogstore            = undef,
   $initialize_datastore    = false,
   # fact from which we get public ip address
   $client_ip               = $::ipaddress,
@@ -76,6 +78,7 @@ class zookeeper(
   class { 'zookeeper::config':
     id                      => $id,
     datastore               => $datastore,
+    datalogstore            => $datalogstore,
     initialize_datastore    => $initialize_datastore,
     client_ip               => $client_ip,
     client_port             => $client_port,

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -185,6 +185,30 @@ describe 'zookeeper::config', :type => :class do
     })}
   end
 
+  context 'without datalogstore parameter' do
+    it { should contain_file(
+        '/etc/zookeeper/conf/zoo.cfg'
+      ).with_content(/# dataLogDir=\/disk2\/zookeeper/)
+    }
+  end
+
+  context 'with datalogstore parameter' do
+    let(:params) {{
+      :datalogstore => '/zookeeper/transaction/device',
+    }}
+
+    let(:datalogstore)  { '/zookeeper/transaction/device' }
+
+    it { should contain_file(datalogstore).with({
+      'ensure'  => 'directory',
+    }) }
+
+    it { should contain_file(
+        '/etc/zookeeper/conf/zoo.cfg'
+      ).with_content(/dataLogDir=\/zookeeper\/transaction\/device/)
+    }
+  end
+
   context 'setting quorum of servers with custom ports' do
     let(:params) {{
       :election_port => 3000,

--- a/templates/conf/zoo.cfg.erb
+++ b/templates/conf/zoo.cfg.erb
@@ -11,7 +11,11 @@ syncLimit=<%= @sync_limit %>
 # the directory where the snapshot is stored.
 dataDir=<%= @datastore %>
 # Place the dataLogDir to a separate physical disc for better performance
+<% if @datalogstore -%>
+dataLogDir=<%= @datalogstore %>
+<% else -%>
 # dataLogDir=/disk2/zookeeper
+<% end -%>
 
 # the port at which the clients will connect
 clientPort=<%= @client_port %>


### PR DESCRIPTION
This exposes the dataLogDir config option in Zookeeper as the puppet parameter $datalogstore, allowing transaction logs and snapshots to be broken out onto separate locations/devices. I chose the $datalogstore parameter for dataLogDir to keep the naming consistent with the existing $datastore parameter for dataDir.

Reasoning for adding this parameter: http://zookeeper.apache.org/doc/trunk/zookeeperAdmin.html "It is highly recommened to dedicate a log device and set dataLogDir to point to a directory on that device, and then make sure to point dataDir to a directory not residing on that device."

The default behavior if this option is not passed to the puppet module remains the same as it is currently.

I have tested this on Debian 7 (wheezy), and verified that not passing this parameter results in no changes to the zoo.cfg file, whereas passing the new parameter results in appropriate creation of the directory, creation of the dataLogDir= parameter value line in zoo.cfg, and proper use of the directory by zookeeper for new topics. Although untested in other OSes, the default of "undef" in combination with "if $datalogstore" and "if @datalogstore" are pretty core puppet/ruby conventions (respectively) that should work across OSes.

Let me know if you'd like anything changed or if this pull request doesn't make sense at this time!