### PR TITLE
Fixed dependency in "initialize_datastore" step

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -145,7 +145,7 @@ class zookeeper::config(
     exec { 'initialize_datastore':
       command => "/usr/bin/zookeeper-server-initialize --myid=${id}",
       user    => $user,
-      creates => "${datastore}/myid",
+      creates => "${datastore}/version-2",
       require => File[$datastore],
     }
   }


### PR DESCRIPTION
"${datastore}/myid" is being created earlier making this step impossible
to run. The result for "zookeeper-server-initialize" creates the
"${datastore}/version-2" folder which is a much better description of
the step. This should address an open issue that the module currently has