### PR TITLE
manage systemd unit files optionally

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,10 +57,12 @@ class zookeeper(
   $java_package            = undef,
   $min_session_timeout     = undef,
   $max_session_timeout     = undef,
+  $manage_systemd          = true,
 ) {
 
   validate_array($packages)
   validate_bool($ensure_cron)
+  validate_bool($manage_systemd)
 
   anchor { 'zookeeper::start': }->
   class { 'zookeeper::install':

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -18,7 +18,7 @@ class zookeeper::service(
     default: { $initstyle = 'unknown' }
   }
 
-  if ($initstyle == 'systemd' and $manage_systemd) {
+  if ($initstyle == 'systemd' and $zookeeper::manage_systemd) {
     file { '/usr/lib/systemd/system/zookeeper.service':
       ensure  => 'present',
       content => template('zookeeper/zookeeper.service.erb'),

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -18,7 +18,7 @@ class zookeeper::service(
     default: { $initstyle = 'unknown' }
   }
 
-  if ($initstyle == 'systemd') {
+  if ($initstyle == 'systemd' and $manage_systemd) {
     file { '/usr/lib/systemd/system/zookeeper.service':
       ensure  => 'present',
       content => template('zookeeper/zookeeper.service.erb'),


### PR DESCRIPTION
Custom rpms can have their own systemd files. Also jar names/paths can differ between rpms.

This PR allows to not install the unitd files on el7 systems.