### PR TITLE
Suggested fix for issue #27

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -21,6 +21,7 @@
 #
 class zookeeper::config(
   $id                      = '1',
+  $ensemble                = false,
   $datastore               = '/var/lib/zookeeper',
   $datalogstore            = undef,
   $initialize_datastore    = false,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,7 @@
 #   class { 'zookeeper': }
 #
 class zookeeper(
-  $ensemble                = hiera('sys11stack::ensemble', false)
+  $ensemble                = hiera('sys11stack::ensemble', false),
   $datastore               = '/var/lib/zookeeper',
   # datalogstore used to put transaction logs in separate location than snapshots
   $datalogstore            = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,6 +81,7 @@ class zookeeper(
   }->
   class { 'zookeeper::config':
     id                      => $id,
+    ensemble                => $ensemble,
     datastore               => $datastore,
     datalogstore            => $datalogstore,
     initialize_datastore    => $initialize_datastore,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,7 @@
 #   class { 'zookeeper': }
 #
 class zookeeper(
-  $id                      = '1',
+  $ensemble                = hiera('sys11stack::ensemble', false)
   $datastore               = '/var/lib/zookeeper',
   # datalogstore used to put transaction logs in separate location than snapshots
   $datalogstore            = undef,
@@ -61,6 +61,8 @@ class zookeeper(
 
   validate_array($packages)
   validate_bool($ensure_cron)
+
+  $id = $ensemble[$::hostname]['myid']
 
   anchor { 'zookeeper::start': }->
   class { 'zookeeper::install':

--- a/templates/conf/zoo.cfg.erb
+++ b/templates/conf/zoo.cfg.erb
@@ -28,7 +28,13 @@ clientPortAddress=<%= @client_ip %>
 #server.2=zookeeper2:2888:3888
 #server.3=zookeeper3:2888:3888
 <% @servers.each_pair do |host, parms| -%>
-<%= "server.%s=%s:%s:%s:%s" %s [ parms[host]['myid'], parms[host]['ip'], parms[host]['election-port'], parms[host]['leader-port'], parms[host]['observer']?'observer':'' %>
+<%= "server.%s=%s:%s:%s:%s" %s [ 
+  parms[host]['myid'], 
+  parms[host]['ip'], 
+  parms[host]['election-port'], 
+  parms[host]['leader-port'], 
+  parms[host]['observer']?'observer':''
+] %>
 <% end -%>
 
 # To avoid seeks ZooKeeper allocates space in the transaction log file in

--- a/templates/conf/zoo.cfg.erb
+++ b/templates/conf/zoo.cfg.erb
@@ -28,12 +28,12 @@ clientPortAddress=<%= @client_ip %>
 #server.2=zookeeper2:2888:3888
 #server.3=zookeeper3:2888:3888
 <% @servers.each_pair do |host, parms| -%>
-<%= "server.%s=%s:%s:%s:%s" %s [ 
+<%= "server.%s=%s:%s:%s%s" % [ 
   parms[host]['myid'], 
   parms[host]['ip'], 
   parms[host]['election-port'], 
   parms[host]['leader-port'], 
-  parms[host]['observer']?'observer':''
+  parms[host]['observer']?':observer':''
 ] %>
 <% end -%>
 

--- a/templates/conf/zoo.cfg.erb
+++ b/templates/conf/zoo.cfg.erb
@@ -27,14 +27,10 @@ clientPortAddress=<%= @client_ip %>
 #server.1=zookeeper1:2888:3888
 #server.2=zookeeper2:2888:3888
 #server.3=zookeeper3:2888:3888
-<% @servers.each_pair do |host, parms| -%>
-<%= "server.%s=%s:%s:%s%s" % [ 
-  parms[host]['myid'], 
-  parms[host]['ip'], 
-  parms[host]['election-port'], 
-  parms[host]['leader-port'], 
-  parms[host]['observer']?':observer':''
-] %>
+<% @ensemble.each_pair do |host, parms|
+  obs = parms['observer']?':observer':''
+-%>
+<%= "server.#{parms['myid']}=#{parms['ip']}:#{parms['leader-port']}:#{parms['election-port']}#{obs}" %>
 <% end -%>
 
 # To avoid seeks ZooKeeper allocates space in the transaction log file in

--- a/templates/conf/zoo.cfg.erb
+++ b/templates/conf/zoo.cfg.erb
@@ -27,12 +27,8 @@ clientPortAddress=<%= @client_ip %>
 #server.1=zookeeper1:2888:3888
 #server.2=zookeeper2:2888:3888
 #server.3=zookeeper3:2888:3888
-<% i = 1 -%>
-<% @servers.each_with_index do |h, i| -%>
-<% if @observers.include? h -%>
-<% observer_text=':observer' -%>
-<% end -%>
-<%= "server.#{i+1}=#{h}:%s:%s%s" % [ @election_port, @leader_port, observer_text ] %>
+<% @servers.each_pair do |host, parms| -%>
+<%= "server.%s=%s:%s:%s:%s" %s [ parms[host]['myid'], parms[host]['ip'], parms[host]['election-port'], parms[host]['leader-port'], parms[host]['observer']?'observer':'' %>
 <% end -%>
 
 # To avoid seeks ZooKeeper allocates space in the transaction log file in


### PR DESCRIPTION
This is a fix for the myid issues referenced in issue #27 and in issue #18.

You can now specify an ensemble as a hash of hashes, and it will generate stable, manually assigned myid files, and a stable server.i ensemble where .i and the myid generated will match.

Parameter wiring needs cleaning up (currently using a global hiera hash sys11stack::ensemble, needs to be changed so that the parameter actually can be chosen).
