### PR TITLE
replacing debian with redhat in the redhat.pp manifest

### DIFF
--- a/manifests/os/redhat.pp
+++ b/manifests/os/redhat.pp
@@ -1,5 +1,5 @@
 #
-# ZooKeeper installation on Debian
+# ZooKeeper installation on Redhat
 class zookeeper::os::redhat(
   $ensure            = present,
   $snap_retain_count = 3,
@@ -30,12 +30,12 @@ class zookeeper::os::redhat(
     if versioncmp($::puppetversion, '3.6.0') >= 0 {
       ensure_resource('package', $java_package,
         {'ensure' => $ensure, 'allow_virtual' => true,
-        'before' => Anchor['zookeeper::os::debian::java']}
+        'before' => Anchor['zookeeper::os::redhat::java']}
       )
     } else {
       ensure_resource('package', $java_package,
         {'ensure' => $ensure,
-        'before' => Anchor['zookeeper::os::debian::java']}
+        'before' => Anchor['zookeeper::os::redhat::java']}
       )
     }
 


### PR DESCRIPTION
Hi,

Sorry to be a bother.

Just noticed I got an error trying to install java when running on CentOS:
Error: Could not find dependent Anchor[zookeeper::os::debian::java] for Package[java-1.8.0-openjdk-headless.x86_64

Just small changes to replace "debian" with "redhat".

Great repo.

Thanks,