### PR TITLE
CentOS7 with mesosphere repo installation fix

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -22,6 +22,7 @@ class zookeeper::service(
     file { '/usr/lib/systemd/system/zookeeper.service':
       ensure  => 'present',
       content => template('zookeeper/zookeeper.service.erb'),
+      replace => "no"
     } ~>
     exec { 'systemctl daemon-reload # for zookeeper':
       refreshonly => true,


### PR DESCRIPTION
Description:

In the case of using Mesos on CentOS 7, proper packages for Zookeeper are made available and the service created through that installation will work fine. Everything else is configurable through hiera properties (zookeeper::user: root and zookeeper::group: root), but the service created from the template provided is breaking the Zookeeper installation from Mesosphere correct zookeeper CentOS7 packages.


* [x] only create zookeeper service if it does not exist - e.g. when zookeeper is installed from cdh5-el6; in case of using mesosphere repo which has an centos7 el7 package for zookeeper - the service is created properly and the template would break zookeeper installation if applied to replace the existing service file.

* [x] Ready for review/merge.