### PR TITLE
Update project non-development dependencies.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,11 +14,11 @@ gem 'rspec-system-serverspec', :require => false
 # coverage reports will be in release 2.0
 gem 'rspec-puppet', '> 2.0'
 gem 'rspec', '~> 2.13'
+gem 'metadata-json-lint', :require => false
 
 # blacksmith > 3.0 does not support ruby 1.8.7
 group :development do
   gem 'puppet-blacksmith',  '~> 3.0'
-  gem 'metadata-json-lint',      :require => false
   gem 'beaker'
   gem 'beaker-rspec', :require => false
 end


### PR DESCRIPTION
Move the metadata-json-lint gem declaration out of the development
group.  The gem is needed for non-development testing as well.