### PR TITLE
Update Puppetfile and fix build.

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,4 +1,4 @@
 forge 'https://forgeapi.puppetlabs.com'
 
-mod 'puppetlabs/stdlib', '>=2.3.3'
-mod 'richardc/datacat'
+mod 'puppetlabs-stdlib', '>=2.3.3', :git => "https://github.com/puppetlabs/puppetlabs-stdlib.git"
+mod 'richardc-datacat', :git => "https://github.com/richardc/puppet-datacat"


### PR DESCRIPTION
Update the source location for the module's dependencies.

Currently librarian-puppet v1.5.0 does not query the correct URL to retrieve dependencies:

```
vagrant@zookeeper-tester:~/deric/puppet-zookeeper# librarian-puppet install --verbose
[Librarian] Ruby Version: 2.1.5
[Librarian] Ruby Platform: x86_64-linux
[Librarian] Rubygems Version: 2.4.8
[Librarian] Librarian Version: 0.6.3
[Librarian] Librarian Adapter: puppet
[Librarian] Librarian Adapter Version: 1.5.0
[Librarian] Project: /root/deric/puppet-zookeeper
[Librarian] Specfile: Puppetfile
[Librarian] Lockfile: Puppetfile.lock
[Librarian] Git: /usr/bin/git
source 'https://rubygems.org'
[Librarian] Git Version: 1.7.10.4
[Librarian] Git Environment Variables:
[Librarian]   (empty)
[Librarian] Pre-Cached Sources:
[Librarian] Post-Cached Sources:
[Librarian]   [:forge, "https://forgeapi.puppetlabs.com", {}]
[Librarian] Resolving puppetlabs-stdlib (>= 2.3.3) <https://forgeapi.puppetlabs.com>
[Librarian]   Checking manifests
[Librarian] Querying Forge API for module puppetlabs-stdlib: https://forgeapi.puppetlabs.com/api/v1/releases.json?module=puppetlabs/stdlib
Unable to find module 'puppetlabs-stdlib' on https://forgeapi.puppetlabs.com
...
```

The puppet forge API docs currently are for v3 of the API and it looks like this route has been deprecated.

This is a workaround to librarian-puppet v1.5.0 not using the correct API syntax to query modules, and instead directly pulls from the projects git repositories.

