### PR TITLE
Added user and group as parameters for zookeeper conf template.

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,6 +5,8 @@ class zookeeper::service(
   $service_name   = 'zookeeper',
   $service_ensure = 'running',
   $manage_systemd = true,
+  $user           = 'zookeeper',
+  $group          = 'zookeeper'
 ){
   require zookeeper::install
 

--- a/templates/zookeeper.service.erb
+++ b/templates/zookeeper.service.erb
@@ -5,8 +5,8 @@
 ExecStart=/bin/sh -c 'set -x; . /etc/zookeeper/conf/environment; CLASSPATH="/usr/lib/zookeeper/zookeeper.jar:/usr/lib/zookeeper/lib/*:$CLASSPATH"; CLASSPATH="$(. /usr/lib/zookeeper/bin/zkEnv.sh ; echo $CLASSPATH)"; mkdir -p /var/log/zookeeper; $JAVA "-Dzookeeper.log.dir=/var/log/zookeeper" "-Dzookeeper.root.logger=INFO,CONSOLE" -cp "$CLASSPATH" $JVMFLAGS "$ZOOMAIN" "$ZOOCFG"
 Restart=always
 SyslogIdentifier=zookeeper
-User=root
-Group=root
+User=<%= @user %>
+Group=<%= @group %>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The user and group name were not being passed to service.pp. The user and group were hardcoded in the zookeeper config file to be 'root', which isn't a very nice thing to do. I added them as parameters to the service.pp file, with 'zookeeper' as default value (as everywhere else in the project).