### PR TITLE
Create user and group to run zookeeper under. 

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,6 +72,7 @@ class zookeeper(
     snap_retain_count => $snap_retain_count,
     datastore         => $datastore,
     user              => $user,
+    group             => $group,
     cleanup_sh        => $cleanup_sh,
     start_with        => $start_with,
     ensure_cron       => $ensure_cron,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -15,6 +15,7 @@ class zookeeper::install(
   $cleanup_sh        = '/usr/lib/zookeeper/bin/zkCleanup.sh',
   $datastore         = '/var/lib/zookeeper',
   $user              = 'zookeeper',
+  $group             = 'zookeeper',
   $start_with        = 'init.d',
   $ensure_cron       = true,
   $service_package   = 'zookeeperd',
@@ -26,6 +27,19 @@ class zookeeper::install(
 ) {
   anchor { 'zookeeper::install::begin': }
   anchor { 'zookeeper::install::end': }
+
+
+  group { $group:
+    ensure => present,
+  } 
+
+  user { $user:
+    comment => 'Zookeeper user',
+    ensure => present,
+    gid => $group,
+    shell => '/sbin/nologin',
+    require => Group['${group}'],
+  } ~>
 
   case $::osfamily {
     'Debian': {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -31,14 +31,14 @@ class zookeeper::install(
 
   group { $group:
     ensure => present,
-  } 
+  }
 
   user { $user:
     comment => 'Zookeeper user',
     ensure => present,
     gid => $group,
     shell => '/sbin/nologin',
-    require => Group['${group}'],
+    require => Group[$group],
   } ~>
 
   case $::osfamily {


### PR DESCRIPTION
At the moment the creation of the zookeeper user and group is not handled by the puppet module. Adding this functionality makes sure the module will also work when the user and group are not created by the rpm or by some other method.