### PR TITLE
don't zookeeper service if already exists

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -22,6 +22,7 @@ class zookeeper::service(
     file { '/usr/lib/systemd/system/zookeeper.service':
       ensure  => 'present',
       content => template('zookeeper/zookeeper.service.erb'),
+      replace => "no"
     } ~>
     exec { 'systemctl daemon-reload # for zookeeper':
       refreshonly => true,


### PR DESCRIPTION
Do not override system service definition.