### PR TITLE
Align Java options between files

### DIFF
--- a/templates/zookeeper.service.erb
+++ b/templates/zookeeper.service.erb
@@ -11,7 +11,7 @@ After=<%=@systemd_unit_after %>
 <% end -%>
 
 [Service]
-ExecStart=/bin/sh -c 'set -x; . <%= @cfg_dir %>/environment; CLASSPATH="<%= @zoo_dir %>/zookeeper.jar:<%= @zoo_dir %>/lib/*:$CLASSPATH"; CLASSPATH="$(. <%= @zoo_dir %>/bin/zkEnv.sh ; echo $CLASSPATH)"; mkdir -p <%= @log_dir %>; $JAVA "-Dzookeeper.log.dir=<%= @log_dir %>" "-Dzookeeper.root.logger=$ZOO_LOG4J_PROP" -cp "$CLASSPATH" $JVMFLAGS "$ZOOMAIN" "$ZOOCFG"'
+ExecStart=/bin/sh -c 'set -x; . <%= @cfg_dir %>/environment; CLASSPATH="<%= @zoo_dir %>/zookeeper.jar:<%= @zoo_dir %>/lib/*:$CLASSPATH"; CLASSPATH="$(. <%= @zoo_dir %>/bin/zkEnv.sh ; echo $CLASSPATH)"; mkdir -p <%= @log_dir %>; $JAVA "-Dzookeeper.log.dir=<%= @log_dir %>" "-Dzookeeper.root.logger=$ZOO_LOG4J_PROP" -cp "$CLASSPATH" $JAVA_OPTS "$ZOOMAIN" "$ZOOCFG"'
 Restart=always
 SyslogIdentifier=zookeeper
 User=<%= @user %>


### PR DESCRIPTION
The systemd service file is using JVMFLAGS environment variable while the environment file is using JAVA_OPTS (and the same is the Puppet class). As a result any attempt to set JAVA_OPTS is ignored when using systemd unit file. 