### PR TITLE
Have $manage_service_file honored for init

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -28,7 +28,7 @@ class zookeeper::service(
       path        => $::path,
       notify      => Service[$service_name]
     }
-  } elsif ($service_provider == 'init') {
+  } elsif ($service_provider == 'init' and $manage_service_file == true) {
     file {"/etc/init.d/${service_name}":
       ensure  => present,
       content => template('zookeeper/zookeeper.init.erb'),


### PR DESCRIPTION
Currently if you're using init as the service_provider type, it will overwrite your service file no matter what you tell it.