### PR TITLE
Update zookeeper.init.erb

### DIFF
--- a/templates/zookeeper.init.erb
+++ b/templates/zookeeper.init.erb
@@ -41,7 +41,7 @@ fi
 
 ZOOBINDIR="/usr/lib/zookeeper/bin"
 ZOOCFGDIR=<%= @cfg_dir %>
-ZOOCFG="/etc/zookeeper/zoo.cfg"
+ZOOCFG="$ZOOCFGDIR/zoo.cfg"
 ZOO_LOG_DIR=<%= @log_dir %>
 
 [ -e "$ZOOCFGDIR/java.env" ] && . "$ZOOCFGDIR/java.env"


### PR DESCRIPTION
In my setup, ZK won't start due to "zoo.cfg" being @ `/etc/zookeeper/zoo.cfg` .  I believe the correct location is `/etc/zookeeper/conf/zoo.cfg`.