### PR TITLE
Fix RedHat 6 service provider

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,7 +32,7 @@ class zookeeper::params {
     }
     'Redhat': {
       case $::operatingsystemmajrelease {
-        '6': { $initstyle = 'upstart' }
+        '6': { $initstyle = 'redhat' }
         '7': { $initstyle = 'systemd' }
         default: { $initstyle = undef }
       }


### PR DESCRIPTION
Upstart is Ubuntu's service provider (https://docs.puppet.com/puppet/latest/reference/type.html#service-provider-upstart)

Redhat should be used in this case
https://docs.puppet.com/puppet/latest/reference/type.html#service-provider-redhat