### PR TITLE
Drop init script on Redhat-derived systems

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -18,23 +18,25 @@ class zookeeper::service(
 ){
   require zookeeper::install
 
-  if ($service_provider == 'systemd' and $manage_service_file == true) {
-    file { '/usr/lib/systemd/system/zookeeper.service':
-      ensure  => 'present',
-      content => template('zookeeper/zookeeper.service.erb'),
-    } ~>
-    exec { 'systemctl daemon-reload # for zookeeper':
-      refreshonly => true,
-      path        => $::path,
-      notify      => Service[$service_name]
-    }
-  } elsif ($service_provider == 'init' and $manage_service_file == true) {
-    file {"/etc/init.d/${service_name}":
-      ensure  => present,
-      content => template('zookeeper/zookeeper.init.erb'),
-      mode    => '0755',
-      notify  => Service[$service_name]
-    }
+  if $manage_service_file == true {
+    if $service_provider == 'systemd'  {
+      file { '/usr/lib/systemd/system/zookeeper.service':
+        ensure  => 'present',
+        content => template('zookeeper/zookeeper.service.erb'),
+        } ~>
+        exec { 'systemctl daemon-reload # for zookeeper':
+          refreshonly => true,
+          path        => $::path,
+          notify      => Service[$service_name]
+        }
+      } elsif ( $service_provider == 'init' or $service_provider == 'redhat')  {
+        file {"/etc/init.d/${service_name}":
+          ensure  => present,
+          content => template('zookeeper/zookeeper.init.erb'),
+          mode    => '0755',
+          notify  => Service[$service_name]
+        }
+      }
   }
 
   service { $service_name:


### PR DESCRIPTION
In addition to switching to the `redhat` service provider on redhat-like systems (handled here: https://github.com/deric/puppet-zookeeper/pull/61), we also need to drop the init script when `service_provider` is set to `redhat`, just like we do when it's set to `init`.