### PR TITLE
Replaces "Redhat" by "RedHat" as it won't match

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,7 +30,7 @@ class zookeeper::params {
         'service_provider' => $initstyle,
       }
     }
-    'Redhat': {
+    'RedHat': {
       case $::operatingsystemmajrelease {
         '6': { $initstyle = 'redhat' }
         '7': { $initstyle = 'systemd' }


### PR DESCRIPTION
Fix typo as the case statement will not match against RHEL/CentOS systems