### PR TITLE
Custom zookeeper ids configurable

### DIFF
--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -218,6 +218,22 @@ describe 'zookeeper::config', :type => :class do
     ).with_content(/server.2=192.168.1.2:3000:4000/) }
   end
 
+  context 'setting quorum of servers with custom ports with servers as hash' do
+    let(:params) {{
+        :election_port => 3000,
+        :leader_port   => 4000,
+        :servers       => {12 => '192.168.1.1', 23 => '192.168.1.2'}
+    }}
+
+    it { should contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).with_content(/server.12=192.168.1.1:3000:4000/) }
+
+    it { should contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).with_content(/server.23=192.168.1.2:3000:4000/) }
+  end
+
   context 'setting quorum of servers with default ports' do
     let(:params) {{
       :servers => ['192.168.1.1', '192.168.1.2']
@@ -230,6 +246,20 @@ describe 'zookeeper::config', :type => :class do
     it { should contain_file(
       '/etc/zookeeper/conf/zoo.cfg'
     ).with_content(/server.2=192.168.1.2:2888:3888/) }
+  end
+
+  context 'setting quorum of servers with default ports with servers as hash' do
+    let(:params) {{
+        :servers => {12 => '192.168.1.1', 23 => '192.168.1.2'}
+    }}
+
+    it { should contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).with_content(/server.12=192.168.1.1:2888:3888/) }
+
+    it { should contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).with_content(/server.23=192.168.1.2:2888:3888/) }
   end
 
   context 'setting quorum of servers with default ports with observer' do
@@ -269,6 +299,45 @@ describe 'zookeeper::config', :type => :class do
     it { should contain_file(
       '/etc/zookeeper/conf/zoo.cfg'
     ).with_content(/server.5=192.168.1.5:2888:3888:observer/) }
+  end
+
+  context 'setting quorum of servers with default ports with observer with servers as hash' do
+    let(:params) {{
+        :servers => {12 => '192.168.1.1', 23 => '192.168.1.2', 34 => '192.168.1.3', 45 => '192.168.1.4', 56 => '192.168.1.5'},
+        :observers => ['192.168.1.4', '192.168.1.5']
+    }}
+
+    it { should contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).with_content(/server.12=192.168.1.1:2888:3888/) }
+
+    it { should_not contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).with_content(/server.12=192.168.1.1:2888:3888:observer/) }
+
+    it { should contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).with_content(/server.23=192.168.1.2:2888:3888/) }
+
+    it { should_not contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).with_content(/server.23=192.168.1.2:2888:3888:observer/) }
+
+    it { should contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).with_content(/server.34=192.168.1.3:2888:3888/) }
+
+    it { should_not contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).with_content(/server.34=192.168.1.3:2888:3888:observer/) }
+
+    it { should contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).with_content(/server.45=192.168.1.4:2888:3888:observer/) }
+
+    it { should contain_file(
+      '/etc/zookeeper/conf/zoo.cfg'
+    ).with_content(/server.56=192.168.1.5:2888:3888:observer/) }
   end
 
   context 'setting minSessionTimeout' do

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -222,7 +222,7 @@ describe 'zookeeper::config', :type => :class do
     let(:params) {{
         :election_port => 3000,
         :leader_port   => 4000,
-        :servers       => {12 => '192.168.1.1', 23 => '192.168.1.2'}
+        :servers       => {'12' => '192.168.1.1', '23' => '192.168.1.2'}
     }}
 
     it { should contain_file(
@@ -250,7 +250,7 @@ describe 'zookeeper::config', :type => :class do
 
   context 'setting quorum of servers with default ports with servers as hash' do
     let(:params) {{
-        :servers => {12 => '192.168.1.1', 23 => '192.168.1.2'}
+        :servers => {'12' => '192.168.1.1', '23' => '192.168.1.2'}
     }}
 
     it { should contain_file(
@@ -303,7 +303,11 @@ describe 'zookeeper::config', :type => :class do
 
   context 'setting quorum of servers with default ports with observer with servers as hash' do
     let(:params) {{
-        :servers => {12 => '192.168.1.1', 23 => '192.168.1.2', 34 => '192.168.1.3', 45 => '192.168.1.4', 56 => '192.168.1.5'},
+        :servers => {'12' => '192.168.1.1',
+                     '23' => '192.168.1.2',
+                     '34' => '192.168.1.3',
+                     '45' => '192.168.1.4',
+                     '56' => '192.168.1.5'},
         :observers => ['192.168.1.4', '192.168.1.5']
     }}
 

--- a/templates/conf/zoo.cfg.erb
+++ b/templates/conf/zoo.cfg.erb
@@ -32,16 +32,19 @@ clientPortAddress=<%= @client_ip %>
 #server.1=zookeeper1:2888:3888
 #server.2=zookeeper2:2888:3888
 #server.3=zookeeper3:2888:3888
-<% i = 1 -%>
-<% @servers.each_with_index do |h, i| -%>
+<% unless @servers.respond_to?(:each_pair) -%>
+<%# make sure @servers is a hash %>
+    <% @servers = Hash[@servers.map.with_index(1) {|e, i|  [i, e] }] %>
+<% end -%>
+<% @servers.each_pair do |id, host| -%>
 <%# make sure port is not included in hostname %>
-<% if h.index(':') -%>
-<% h = h[0...(h.index(':'))] -%>
-<% end -%>
-<% if @observers.include? h -%>
-<% observer_text=':observer' -%>
-<% end -%>
-<%= "server.#{i+1}=#{h}:%s:%s%s" % [ @election_port, @leader_port, observer_text ] -%>
+    <% if host.index(':') -%>
+        <% host = host[0...(host.index(':'))] -%>
+    <% end -%>
+    <% if @observers.include? host -%>
+        <% observer_text=':observer' -%>
+    <% end -%>
+    <%= "server.#{id}=#{host}:%s:%s%s" % [@election_port, @leader_port, observer_text ] -%>
 <% end -%>
 
 # To avoid seeks ZooKeeper allocates space in the transaction log file in


### PR DESCRIPTION
Zookeeper servers can now be specified by a hash or an array. If it is a hash, the keys will be the server ids.

E.g.`:servers => {'12' => '192.168.1.1', '23' => '192.168.1.2'}` will result in 
```
server.12=192.168.1.1:2888:3888
server.23=192.168.1.2:2888:3888
```
in the zoo.cfg file. If it is an array, it works as before.