### PR TITLE
Add ability to install from archive file

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,3 +1,4 @@
 forge 'https://forgeapi.puppetlabs.com'
 
 mod 'puppetlabs-stdlib', '>= 2.3.3 < 5.0.0'
+mod 'puppet/archive', '>= 0.5.0'

--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ After=network-online.target
    - `manage_service` (default: `true`) whether Puppet should ensure running service
    - `manage_service_file` when enabled on RHEL 7.0 a systemd config will be managed
    - `ensure_account` controls whether `zookeeper` user and group will be ensured (set to `false` to disable this feature)
+   - `install_method` (default: `package`) - installation method (either `package` or `archive`). `package` will use the available package manager. `archive` will install from an archive file.
+   - `mirror_url` - Base URL of Apache mirror to use if `install_method` is `archive`
+   - `archive_checksum` - optional hash to use when verifying installation archive. ex: `{ type => 'sha1', hash => 'abcdef123456' }`
 
 and many others, see the `init.pp` file for more details.
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -131,6 +131,12 @@ class zookeeper::config(
     content => template('zookeeper/conf/environment.erb'),
   }
 
+  file { "${cfg_dir}/zookeeper-env.sh":
+    ensure  => 'link',
+    target  => "${cfg_dir}/environment",
+    require => File["${cfg_dir}/environment"]
+  }
+
   file { "${cfg_dir}/log4j.properties":
     owner   => $user,
     group   => $group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,6 +51,9 @@ class zookeeper(
   $peer_type               = 'UNSET',
   $start_with              = undef,
   $ensure_cron             = true,
+  $install_method          = 'package',
+  $mirror_url              = 'http://mirror.cogentco.com/pub/apache',
+  $archive_checksum        = {},
   $service_package         = undef,
   $service_name            = $::zookeeper::params::service_name,
   $service_provider        = $::zookeeper::params::service_provider,
@@ -104,6 +107,10 @@ class zookeeper(
   anchor { 'zookeeper::start': }->
   class { 'zookeeper::install':
     ensure            => $ensure,
+    install_method    => $install_method,
+    mirror_url        => $mirror_url,
+    archive_checksum  => $archive_checksum,
+    zoo_dir           => $zoo_dir,
     snap_retain_count => $snap_retain_count,
     datastore         => $datastore,
     user              => $user,

--- a/manifests/install/archive.pp
+++ b/manifests/install/archive.pp
@@ -1,0 +1,90 @@
+# Class: zookeeper::install::archive
+#
+# This module manages Zookeeper installation from an archive file supported by
+# the 'archive' type
+#
+# Parameters: None
+#
+# Actions: None
+#
+#
+# Should not be included directly
+#
+class zookeeper::install::archive(
+  $mirror_url        = $::zookeeper::install::mirror_url,
+  $install_dir       = $::zookeeper::install::zoo_dir,
+  $archive_checksum  = $::zookeeper::install::archive_checksum,
+  $package_dir       = $::zookeeper::install::package_dir,
+  $ensure            = $::zookeeper::install::ensure,
+  $snap_retain_count = $::zookeeper::install::snap_retain_count,
+  $cleanup_sh        = $::zookeeper::install::cleanup_sh,
+  $datastore         = $::zookeeper::install::datastore,
+  $user              = $::zookeeper::install::user,
+  $group             = $::zookeeper::install::group,
+  $ensure_account    = $::zookeeper::install::ensure_account,
+  $service_provider  = $::zookeeper::install::service_provider,
+  $ensure_cron       = $::zookeeper::install::ensure_cron,
+  $service_package   = $::zookeeper::install::service_package,
+  $packages          = $::zookeeper::install::packages,
+  $cdhver            = $::zookeeper::install::cdhver,
+  $install_java      = $::zookeeper::install::install_java,
+  $java_package      = $::zookeeper::install::java_package,
+  $repo              = $::zookeeper::install::repo,
+  $manual_clean      = $::zookeeper::install::manual_clean,
+) {
+
+  include '::archive'
+
+  $basefilename = "zookeeper-${ensure}.tar.gz"
+  $package_url = "${mirror_url}/zookeeper/zookeeper-${ensure}/${basefilename}"
+  $extract_path = "${install_dir}-${ensure}"
+
+  package { ['zookeeper','zookeeperd']:
+    ensure => absent
+  }
+
+  file { $install_dir:
+    ensure => link,
+    target => $extract_path
+  }
+
+  file { $package_dir:
+    ensure  => directory,
+    owner   => 'zookeeper',
+    group   => 'zookeeper',
+    require => [
+      Group['zookeeper'],
+      User['zookeeper'],
+    ],
+  }
+
+  file { $extract_path:
+    ensure  => directory,
+    owner   => 'zookeeper',
+    group   => 'zookeeper',
+    require => [
+      Group['zookeeper'],
+      User['zookeeper'],
+    ],
+  }
+
+  archive { "${package_dir}/${basefilename}":
+    ensure          => present,
+    extract         => true,
+    extract_command => 'tar xfz %s --strip-components=1',
+    extract_path    => $extract_path,
+    source          => $package_url,
+    checksum        => $archive_checksum['hash'],
+    checksum_type   => $archive_checksum['type'],
+    creates         => "${extract_path}/lib",
+    cleanup         => true,
+    user            => 'zookeeper',
+    group           => 'zookeeper',
+    require         => [
+      File[$package_dir],
+      File[$install_dir],
+      Group['zookeeper'],
+      User['zookeeper'],
+    ],
+  }
+}

--- a/manifests/install/package.pp
+++ b/manifests/install/package.pp
@@ -1,0 +1,68 @@
+# Class: zookeeper::install::package
+#
+# This module manages Zookeeper installation through a package manager
+#
+# Parameters: None
+#
+# Actions: None
+#
+#
+# Should not be included directly
+#
+class zookeeper::install::package(
+  $ensure             = $::zookeeper::install::ensure,
+  $snap_retain_count  = $::zookeeper::install::snap_retain_count,
+  $cleanup_sh         = $::zookeeper::install::cleanup_sh,
+  $datastore          = $::zookeeper::install::datastore,
+  $user               = $::zookeeper::install::user,
+  $group              = $::zookeeper::install::group,
+  $ensure_account     = $::zookeeper::install::ensure_account,
+  $service_provider   = $::zookeeper::install::service_provider,
+  $ensure_cron        = $::zookeeper::install::ensure_cron,
+  $service_package    = $::zookeeper::install::service_package,
+  $packages           = $::zookeeper::install::packages,
+  $cdhver             = $::zookeeper::install::cdhver,
+  $install_java       = $::zookeeper::install::install_java,
+  $java_package       = $::zookeeper::install::java_package,
+  $repo               = $::zookeeper::install::repo,
+  $manual_clean       = $::zookeeper::install::manual_clean,
+) {
+
+  $repo_source = is_hash($repo) ? {
+        true  => 'custom',
+        false =>  $repo,
+  }
+  case $::osfamily {
+    'Debian': {
+      class { 'zookeeper::os::debian':
+        ensure           => $ensure,
+        service_provider => $service_provider,
+        service_package  => $service_package,
+        packages         => $packages,
+        before           => Anchor['zookeeper::install::end'],
+        require          => Anchor['zookeeper::install::begin'],
+        install_java     => $install_java,
+        java_package     => $java_package
+      }
+    }
+    'RedHat': {
+      class { 'zookeeper::repo':
+        source => $repo_source,
+        cdhver => $cdhver,
+        config => $repo
+      }
+
+      class { 'zookeeper::os::redhat':
+        ensure       => $ensure,
+        packages     => $packages,
+        require      => Anchor['zookeeper::install::begin'],
+        before       => Anchor['zookeeper::install::end'],
+        install_java => $install_java,
+        java_package => $java_package
+      }
+    }
+    default: {
+      fail("Module '${module_name}' is not supported on OS: '${::operatingsystem}', family: '${::osfamily}'")
+    }
+  }
+}

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -23,20 +23,22 @@ class zookeeper::service(
       file { '/usr/lib/systemd/system/zookeeper.service':
         ensure  => 'present',
         content => template('zookeeper/zookeeper.service.erb'),
-        } ~>
-        exec { 'systemctl daemon-reload # for zookeeper':
-          refreshonly => true,
-          path        => $::path,
-          notify      => Service[$service_name]
-        }
-      } elsif ( $service_provider == 'init' or $service_provider == 'redhat')  {
+        before  => Service[$service_name],
+      } ~>
+      exec { 'systemctl daemon-reload # for zookeeper':
+        refreshonly => true,
+        path        => $::path,
+        notify      => Service[$service_name],
+      }
+    } elsif ( $service_provider == 'init' or $service_provider == 'redhat')  {
         file {"/etc/init.d/${service_name}":
           ensure  => present,
-          content => template('zookeeper/zookeeper.init.erb'),
+          content => template("zookeeper/zookeeper.${::osfamily}.init.erb"),
           mode    => '0755',
-          notify  => Service[$service_name]
+          before  => Service[$service_name],
+          notify  => Service[$service_name],
         }
-      }
+    }
   }
 
   service { $service_name:

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -317,4 +317,61 @@ describe 'zookeeper::install', :type => :class do
       it { should_not contain_user('zookeeper') }
     end
   end
+
+  context 'installing from tar archive' do
+    let(:user) { 'zookeeper' }
+    let(:group) { 'zookeeper' }
+    let(:package_dir) { '/tmp/zookeeper' }
+    let(:zoo_dir) { '/opt/zookeeper' }
+    let(:vers) { '3.4.5' }
+    let(:mirror_url) { 'http://mirror.cogentco.com/pub/apache' }
+    let(:basefilename) { "zookeeper-#{vers}.tar.gz" }
+    let(:package_url) { "#{mirror_url}/zookeeper/zookeeper-#{vers}/zookeeper-#{vers}.tar.gz" }
+    let(:extract_path) { "#{zoo_dir}-#{vers}" }
+
+    let(:facts) {{
+      :operatingsystem => 'Ubuntu',
+      :osfamily => 'Debian',
+      :lsbdistcodename => 'trusty',
+    }}
+
+    let(:params) { {
+      :install_method => 'archive',
+      :package_dir    => package_dir,
+      :zoo_dir        => zoo_dir,
+      :ensure         => vers,
+      :mirror_url     => mirror_url,
+    } }
+
+    it do
+      should contain_file(package_dir).with({
+        :ensure => 'directory',
+        :owner  => user,
+        :group  => group,
+      })
+    end
+    it do
+      should contain_file(extract_path).with({
+        :ensure => 'directory',
+        :owner  => user,
+        :group  => group,
+      })
+    end
+    it do
+      should contain_file(zoo_dir).with({
+        :ensure => 'link',
+        :target => extract_path,
+      })
+    end
+    it do
+      should contain_archive("#{package_dir}/#{basefilename}").with({
+        :extract_path => extract_path,
+        :source       => package_url,
+        :creates      => "#{extract_path}/lib",
+        :user         => user,
+        :group        => group,
+      })
+    end
+	end
+
 end

--- a/templates/conf/environment.erb
+++ b/templates/conf/environment.erb
@@ -6,7 +6,6 @@ ZOOCFGDIR=<%= @cfg_dir %>
 # seems, that log4j requires the log4j.properties file to be in the classpath
 CLASSPATH="$ZOOCFGDIR:/usr/share/java/jline.jar:/usr/share/java/log4j-1.2.jar:/usr/share/java/xercesImpl.jar:/usr/share/java/xmlParserAPIs.jar:/usr/share/java/netty.jar:/usr/share/java/slf4j-api.jar:/usr/share/java/slf4j-log4j12.jar:/usr/share/java/zookeeper.jar"
 
-ZOOCFG="$ZOOCFGDIR/zoo.cfg"
 ZOO_LOG_DIR=<%= @log_dir %>
 USER=<%= @user %>
 GROUP=<%= @group %>
@@ -18,3 +17,4 @@ ZOOMAIN="<%= @zoo_main %>"
 ZOO_LOG4J_PROP="<%= @log4j_prop %>"
 JMXLOCALONLY=false
 JAVA_OPTS="<%= @java_opts %>"
+SERVER_JVMFLAGS=$JAVA_OPTS

--- a/templates/zookeeper.Debian.init.erb
+++ b/templates/zookeeper.Debian.init.erb
@@ -1,0 +1,187 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:          zookeeper
+# Required-Start:    $remote_fs
+# Required-Stop:     $remote_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: centralized coordination service
+# Description:       ZooKeeper is a centralized service for maintaining
+#                    configuration information, naming, providing distributed
+#                    synchronization, and providing group services.
+### END INIT INFO
+
+# Author: Foo Bar <foobar@baz.org>
+#
+# Please remove the "Author" lines above and replace them
+# with your own name if you copy and modify this script.
+
+# Do NOT "set -e"
+
+ZOOBINDIR="<%= @zoo_dir %>/bin"
+ZOOCFGDIR=<%= @cfg_dir %>
+ZOOCFG="$ZOOCFGDIR/zoo.cfg"
+ZOO_LOG_DIR=<%= @log_dir %>
+
+[ -r "$ZOOCFGDIR/environment" ] || exit 0
+. "$ZOOCFGDIR/environment"
+
+[ -e "$ZOOCFGDIR/java.env" ] && . "$ZOOCFGDIR/java.env"
+
+[ "x$ZOO_LOG4J_PROP" = "x" ] && ZOO_LOG4J_PROP="<%= @log4j_prop %>"
+
+# PATH should only include /usr/* if it runs after the mountnfs.sh script
+#
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+DESC="centralized coordination service"
+SCRIPTNAME=/etc/init.d/$NAME
+
+# Read configuration variable file if it is present
+[ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+for f in ${ZOOBINDIR}/../zookeeper-*.jar
+do
+    CLASSPATH="$CLASSPATH:$f"
+done
+
+ZOOLIBDIR=${ZOOLIBDIR:-$ZOOBINDIR/../lib}
+for i in "$ZOOLIBDIR"/*.jar
+do
+    CLASSPATH="$CLASSPATH:$i"
+done
+
+#add the zoocfg dir to classpath
+CLASSPATH=$ZOOCFGDIR:$CLASSPATH
+
+# Load the VERBOSE setting and other rcS variables
+. /lib/init/vars.sh
+
+# Define LSB log_* functions.
+# Depend on lsb-base (>= 3.0-6) to ensure that this file is present.
+. /lib/lsb/init-functions
+
+is_running()
+{
+	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $JAVA --user $USER --test > /dev/null \
+		|| return 1
+    return 0
+}
+
+#
+# Function that starts the daemon/service
+#
+do_start()
+{
+	# Return
+	#   0 if daemon has been started
+	#   1 if daemon was already running
+	#   2 if daemon could not be started
+    is_running || return 1
+
+    if [ ! -d $PIDDIR ]
+    then
+      mkdir -p $PIDDIR
+    fi
+    chown $USER:$GROUP $PIDDIR
+
+    if [ ! -d  $ZOO_LOG_DIR ]
+    then
+      mkdir -p $ZOO_LOG_DIR
+    fi
+    chown $USER:$GROUP $ZOO_LOG_DIR
+
+	start-stop-daemon --start --quiet \
+               --pidfile $PIDFILE \
+               --make-pidfile \
+               --chuid $USER:$GROUP \
+               --background \
+               --exec $JAVA -- \
+                 -cp $CLASSPATH \
+                 $JAVA_OPTS \
+                 $JVM_FLAGS \
+                 -Dzookeeper.log.dir=${ZOO_LOG_DIR} \
+                 -Dzookeeper.root.logger=${ZOO_LOG4J_PROP} \
+                 $ZOOMAIN $ZOOCFG \
+		|| return 2
+}
+
+#
+# Function that stops the daemon/service
+#
+do_stop()
+{
+	# Return
+	#   0 if daemon has been stopped
+	#   1 if daemon was already stopped
+	#   2 if daemon could not be stopped
+	#   other if a failure occurred
+	is_running && return 1
+
+	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE
+	RETVAL="$?"
+	[ "$RETVAL" = 2 ] && return 2
+	# Many daemons don't delete their pidfiles when they exit.
+	[ "$RETVAL" = 0 ] && rm -f $PIDFILE
+	return "$RETVAL"
+}
+
+case "$1" in
+  start)
+        if [ "x$JMXDISABLE" = "x" ]
+        then
+            [ "$VERBOSE" != no ] && log_action_msg "$NAME: JMX enabled by default"
+            # for some reason these two options are necessary on jdk6 on Ubuntu
+            #   accord to the docs they are not necessary, but otw jconsole cannot
+            #   do a local attach
+            JAVA_OPTS="$JAVA_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=$JMXLOCALONLY"
+        else
+            [ "$VERBOSE" != no ] && log_action_msg "$NAME: JMX disabled by user request"
+        fi
+
+	[ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+	do_start
+	case "$?" in
+		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+	esac
+	;;
+  stop)
+	[ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+	do_stop
+	case "$?" in
+		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+	esac
+	;;
+  status)
+       status_of_proc -p $PIDFILE "$NAME" "$NAME" && exit 0 || exit $?
+       ;;
+  restart|force-reload)
+	#
+	# If the "reload" option is implemented then remove the
+	# 'force-reload' alias
+	#
+	log_daemon_msg "Restarting $DESC" "$NAME"
+	do_stop
+	case "$?" in
+	  0|1)
+		do_start
+		case "$?" in
+			0) log_end_msg 0 ;;
+			1) log_end_msg 1 ;; # Old process is still running
+			*) log_end_msg 1 ;; # Failed to start
+		esac
+		;;
+	  *)
+	  	# Failed to stop
+		log_end_msg 1
+		;;
+	esac
+	;;
+  *)
+	echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+	exit 3
+	;;
+esac
+
+:

--- a/templates/zookeeper.RedHat.init.erb
+++ b/templates/zookeeper.RedHat.init.erb
@@ -39,12 +39,13 @@ else
     ZOOMAIN=<%= @zoo_main %>
 fi
 
-ZOOBINDIR="/usr/lib/zookeeper/bin"
+ZOOBINDIR="<%= @zoo_dir %>/bin"
 ZOOCFGDIR=<%= @cfg_dir %>
 ZOOCFG="$ZOOCFGDIR/zoo.cfg"
 ZOO_LOG_DIR=<%= @log_dir %>
 
 [ -e "$ZOOCFGDIR/java.env" ] && . "$ZOOCFGDIR/java.env"
+[ -e "$ZOOCFGDIR/environment" ] && . "$ZOOCFGDIR/environment"
 
 [ "x$ZOO_LOG4J_PROP" = "x" ] && ZOO_LOG4J_PROP="<%= @log4j_prop %>"
 
@@ -62,7 +63,7 @@ done
 #add the zoocfg dir to classpath
 CLASSPATH=$ZOOCFGDIR:$CLASSPATH
 
-cmd="java  \"-Dzookeeper.log.dir=${ZOO_LOG_DIR}\" \"-Dzookeeper.root.logger=${ZOO_LOG4J_PROP}\" -cp ${CLASSPATH} ${JVMFLAGS} ${ZOOMAIN} ${ZOOCFG} & echo \$! > ${pidfile}"
+cmd="java  \"-Dzookeeper.log.dir=${ZOO_LOG_DIR}\" \"-Dzookeeper.root.logger=${ZOO_LOG4J_PROP}\" -cp ${CLASSPATH} ${JAVA_OPTS} ${JVMFLAGS} ${ZOOMAIN} ${ZOOCFG} & echo \$! > ${pidfile}"
 
 
 start() {


### PR DESCRIPTION
New params:
- **install_method** - installation method (either `package` or `archive`). `package` will use the available package manager; `archive` will install from an
- **mirror_url** - Base URL of Apache mirror to use if `install_method` is `archive`
- **archive_checksum** - optional hash to use when verifying installation archive.  ex: `{ type => 'sha1', hash => 'abcdef123456' }`

Add dependency on `puppet/archive`

Move installation logic into their own classes - `zookeeper::install::package` & `zookeeper::install::archive`

Add Debian & RedHat specific init script

Symlink zookeeper-env.sh to environment. Some Zookeeper scripts look for zookeeper-env.sh

Set both $JAVA_OPTS and $SERVER_JVMFLAGS environment variables. Various bundled scripts expect one of these to be set
