### PR TITLE
parameterize environment file

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -64,7 +64,7 @@ class zookeeper::config {
     content => template("${module_name}/conf/zoo.cfg.erb"),
   }
 
-  file { "${::zookeeper::cfg_dir}/environment":
+  file { "${::zookeeper::cfg_dir}/${::zookeeper::environment_file}":
     owner   => $::zookeeper::user,
     group   => $::zookeeper::group,
     mode    => '0644',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,6 +65,7 @@ class zookeeper(
   $zoo_dir                 = $::zookeeper::params::zoo_dir,
   $zoo_main                = $::zookeeper::params::zoo_main,
   # log4j properties
+  $environment_file        = $::zookeeper::params::environment_file,
   $log4j_prop              = $::zookeeper::params::log4j_prop,
   $max_allowed_connections = $::zookeeper::params::max_allowed_connections,
   $peer_type               = $::zookeeper::params::peer_type,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -125,6 +125,7 @@ class zookeeper::params {
   $zoo_main = 'org.apache.zookeeper.server.quorum.QuorumPeerMain'
 
   # log4j properties
+  $environment_file = 'environment'
   $log4j_prop = 'INFO,ROLLINGFILE'
   $peer_type = 'UNSET'
   $rollingfile_threshold = 'INFO'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -50,7 +50,7 @@ class zookeeper::service {
     ],
     subscribe  => [
       File["${::zookeeper::cfg_dir}/myid"], File["${::zookeeper::cfg_dir}/zoo.cfg"],
-      File["${::zookeeper::cfg_dir}/environment"], File["${::zookeeper::cfg_dir}/log4j.properties"],
+      File["${::zookeeper::cfg_dir}/${::zookeeper::environment_file}"], File["${::zookeeper::cfg_dir}/log4j.properties"],
     ]
   }
 }

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -84,6 +84,21 @@ describe 'zookeeper::config' do
       end
     end
 
+    context 'extra environment_file parameter' do
+       # set custom params
+       let :pre_condition do
+         'class {"zookeeper":
+            log4j_prop => "ERROR",
+            environment_file => "java.env",
+          }'
+       end
+ 
+       it do
+         should contain_file('/etc/zookeeper/conf/java.env').with_content(/ERROR/)
+         should_not contain_file('/etc/zookeeper/environment')
+       end
+    end
+
     context 'max allowed connections' do
       let :pre_condition do
         'class {"zookeeper":

--- a/templates/zookeeper.Debian.init.erb
+++ b/templates/zookeeper.Debian.init.erb
@@ -23,8 +23,8 @@ ZOOCFGDIR=<%= scope.lookupvar("zookeeper::cfg_dir") %>
 ZOOCFG="$ZOOCFGDIR/zoo.cfg"
 ZOO_LOG_DIR=<%= scope.lookupvar("zookeeper::log_dir") %>
 
-[ -r "$ZOOCFGDIR/environment" ] || exit 0
-. "$ZOOCFGDIR/environment"
+[ -r "$ZOOCFGDIR/<%= scope.lookupvar("zookeeper::environment_file") %>" ] || exit 0
+. "$ZOOCFGDIR/<%= scope.lookupvar("zookeeper::environment_file") %>"
 
 [ -e "$ZOOCFGDIR/java.env" ] && . "$ZOOCFGDIR/java.env"
 

--- a/templates/zookeeper.RedHat.init.erb
+++ b/templates/zookeeper.RedHat.init.erb
@@ -45,7 +45,7 @@ ZOOCFG="$ZOOCFGDIR/zoo.cfg"
 ZOO_LOG_DIR=<%= scope.lookupvar("zookeeper::log_dir") %>
 
 [ -e "$ZOOCFGDIR/java.env" ] && . "$ZOOCFGDIR/java.env"
-[ -e "$ZOOCFGDIR/environment" ] && . "$ZOOCFGDIR/environment"
+[ -e "$ZOOCFGDIR/<%= scope.lookupvar("zookeeper::environment_file") %>" ] && . "$ZOOCFGDIR/<%= scope.lookupvar("zookeeper::environment_file") %>"
 
 [ "x$ZOO_LOG4J_PROP" = "x" ] && ZOO_LOG4J_PROP="<%= scope.lookupvar("zookeeper::log4j_prop") %>"
 

--- a/templates/zookeeper.service.erb
+++ b/templates/zookeeper.service.erb
@@ -11,7 +11,7 @@ After=<%= scope.lookupvar("zookeeper::systemd_unit_after") %>
 <% end -%>
 
 [Service]
-ExecStart=/bin/sh -c 'set -x; . <%= scope.lookupvar("zookeeper::cfg_dir") %>/environment; CLASSPATH="<%= @_zoo_dir %>/zookeeper.jar:<%= @_zoo_dir %>/lib/*:$CLASSPATH"; CLASSPATH="$(. <%= scope.lookupvar("zookeeper::service::_zoo_dir") %>/bin/zkEnv.sh ; echo $CLASSPATH)"; mkdir -p <%= scope.lookupvar("zookeeper::log_dir") %>; $JAVA "-Dzookeeper.log.dir=<%= scope.lookupvar("zookeeper::log_dir") %>" "-Dzookeeper.root.logger=$ZOO_LOG4J_PROP" -cp "$CLASSPATH" $JAVA_OPTS "$ZOOMAIN" "$ZOOCFG"'
+ExecStart=/bin/sh -c 'set -x; . <%= scope.lookupvar("zookeeper::cfg_dir") %>/<%= scope.lookupvar("zookeeper::environment_file") %>; CLASSPATH="<%= @_zoo_dir %>/zookeeper.jar:<%= @_zoo_dir %>/lib/*:$CLASSPATH"; CLASSPATH="$(. <%= scope.lookupvar("zookeeper::service::_zoo_dir") %>/bin/zkEnv.sh ; echo $CLASSPATH)"; mkdir -p <%= scope.lookupvar("zookeeper::log_dir") %>; $JAVA "-Dzookeeper.log.dir=<%= scope.lookupvar("zookeeper::log_dir") %>" "-Dzookeeper.root.logger=$ZOO_LOG4J_PROP" -cp "$CLASSPATH" $JAVA_OPTS "$ZOOMAIN" "$ZOOCFG"'
 Restart=always
 RemainAfterExit=no
 SyslogIdentifier=zookeeper


### PR DESCRIPTION
Official zookeeper packages try to load variables from java.env file instead of environment. This PR allows to parameterize the environment file path.