### PR TITLE
Add exhibitor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Some reasonable values are:
   * `upstart` - Ubuntu
   * `systemd` - RHEL 7, Debian 8
   * `runit`
+  * `exhibitor` - zookeeper process and config will be managed by exhibitor (https://github.com/soabase/exhibitor). Exhibitor is not managed by this module.
   * `none` - service won't be installed
 
 Parameter `manage_service_file` controls whether service definition should be managed by Puppet (default: `false`). Currently supported for `systemd` and `init`.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -40,28 +40,29 @@ class zookeeper::config {
     }
   }
 
-  # we should notify Class['::zookeeper::service'] however it's not configured
-  # at this point (first run), so we have to subscribe from service declaration
-  file { "${::zookeeper::cfg_dir}/myid":
-    ensure  => file,
-    content => template("${module_name}/conf/myid.erb"),
-    owner   => $::zookeeper::user,
-    group   => $::zookeeper::group,
-    mode    => '0644',
-    require => File[$::zookeeper::cfg_dir],
+  if $::zookeeper::service_provider != 'exhibitor' {
+    file { "${::zookeeper::cfg_dir}/zoo.cfg":
+      owner   => $::zookeeper::user,
+      group   => $::zookeeper::group,
+      mode    => '0644',
+      content => template("${module_name}/conf/zoo.cfg.erb"),
+    }
+
+    # we should notify Class['::zookeeper::service'] however it's not configured
+    # at this point (first run), so we have to subscribe from service declaration
+    file { "${::zookeeper::cfg_dir}/myid":
+      ensure  => file,
+      content => template("${module_name}/conf/myid.erb"),
+      owner   => $::zookeeper::user,
+      group   => $::zookeeper::group,
+      mode    => '0644',
+      require => File[$::zookeeper::cfg_dir],
+    }
   }
 
   file { "${::zookeeper::datastore}/myid":
     ensure  => 'link',
     target  => "${::zookeeper::cfg_dir}/myid",
-    require => File["${::zookeeper::cfg_dir}/myid"]
-  }
-
-  file { "${::zookeeper::cfg_dir}/zoo.cfg":
-    owner   => $::zookeeper::user,
-    group   => $::zookeeper::group,
-    mode    => '0644',
-    content => template("${module_name}/conf/zoo.cfg.erb"),
   }
 
   file { "${::zookeeper::cfg_dir}/${::zookeeper::environment_file}":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -118,7 +118,7 @@ class zookeeper(
     }
   }
 
-  if ($manage_service) {
+  if ($manage_service) and ($service_provider != 'exhibitor') {
     class { 'zookeeper::service':
       require => Class['::zookeeper::config'],
       before  => Anchor['zookeeper::end'],

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -298,4 +298,19 @@ describe 'zookeeper', :type => :class do
     end
 
   end
+
+  context 'managed by exhibitor' do
+    let(:params) do
+      {
+        :service_provider => 'exhibitor',
+        :service_name => 'zookeeper',
+        :cfg_dir => '/opt/zookeeper/conf',
+      }
+    end
+
+    it { is_expected.not_to contain_class('zookeeper::service') }
+    it { is_expected.not_to contain_service('zookeeper') }
+    it { is_expected.not_to contain_file('/opt/zookeeper/conf/zoo.cfg') }
+    it { is_expected.not_to contain_file('/opt/zookeeper/conf/myid') }
+  end
 end

--- a/templates/conf/environment.erb
+++ b/templates/conf/environment.erb
@@ -6,7 +6,7 @@ ZOOCFGDIR=<%= scope.lookupvar("zookeeper::cfg_dir") %>
 # seems, that log4j requires the log4j.properties file to be in the classpath
 CLASSPATH="$ZOOCFGDIR:/usr/share/java/jline.jar:/usr/share/java/log4j-1.2.jar:/usr/share/java/xercesImpl.jar:/usr/share/java/xmlParserAPIs.jar:/usr/share/java/netty.jar:/usr/share/java/slf4j-api.jar:/usr/share/java/slf4j-log4j12.jar:/usr/share/java/zookeeper.jar"
 
-ZOOCFG="$ZOOCFGDIR/zoo.cfg"
+ZOOCFG="zoo.cfg"
 ZOO_LOG_DIR=<%= scope.lookupvar("zookeeper::log_dir") %>
 USER=<%= scope.lookupvar("zookeeper::user") %>
 GROUP=<%= scope.lookupvar("zookeeper::group") %>


### PR DESCRIPTION
Let the zookeeper process and config be managed by an existing install
of exhibitor (this will not install or manage the exhibitor service).

If `$service_provider` is set to `exhibitor` do not create the `zoo.cfg` or
`myid` files, and do not configure a system service. Exhibitor will
create the config file and manage the zookeeper process.

https://github.com/soabase/exhibitor