### PR TITLE
[Issue #87] Refactor zookeeper user & group creation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -107,6 +107,22 @@ class zookeeper(
     false => $repo
   }
 
+  if $::zookeeper::ensure_account {
+    group { $group:
+      ensure => $ensure_account,
+    }
+
+    user { $user:
+      ensure  => $ensure_account,
+      home    => $datastore,
+      comment => 'Zookeeper',
+      gid     => $group,
+      shell   => $shell,
+      require => Group[$group]
+    }
+  }
+
+
   anchor { 'zookeeper::start': }->
   class { 'zookeeper::install': }->
   class { 'zookeeper::config': }

--- a/manifests/post_install.pp
+++ b/manifests/post_install.pp
@@ -6,26 +6,6 @@
 # PRIVATE CLASS - do not use directly (use main `zookeeper` class).
 class zookeeper::post_install {
 
-  # Make sure user and group exists for ZooKeeper #49, if the OS package
-  # doesn't handle its creation.
-  if ($::zookeeper::ensure_account){
-    ensure_resource('group',
-      [$::zookeeper::group],
-      {'ensure' => $::zookeeper::ensure_account}
-    )
-
-    ensure_resource('user',
-      [$::zookeeper::user],
-      {
-        'ensure'  => $::zookeeper::ensure_account,
-        'home'    => $::zookeeper::datastore,
-        'comment' => 'Zookeeper',
-        'gid'     => $::zookeeper::group,
-        'shell'   => $::zookeeper::shell,
-        'require' => Group[$::zookeeper::group]
-      }
-    )
-  }
   if ($::zookeeper::manual_clean) {
     # User defined value
     $_clean = $::zookeeper::manual_clean


### PR DESCRIPTION
Move account creation into `init.pp`. Doing this in the post_install phase causes dependency cycles caused by `file` resources defined before the post install phase.

From https://docs.puppet.com/puppet/latest/types/file.html:
> Autorequires: If Puppet is managing the user or group that owns a file,
> the file resource will autorequire them. If Puppet is managing any
> parent directories of a file, the file resource will autorequire them.

`ensure_resource` isn't providing any benefit over declaring
`file` and `group` directly. This would only help if another resource
was also using `ensure_resource` to create a user and group that matches
the title and parameters.
(https://github.com/puppetlabs/puppetlabs-stdlib#ensure_resource)