### PR TITLE
Service filename should be equal to the service name

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -18,7 +18,7 @@ class zookeeper::service {
 
   if $::zookeeper::manage_service_file == true {
     if $::zookeeper::service_provider == 'systemd'  {
-      file { '/usr/lib/systemd/system/zookeeper.service':
+      file { "/usr/lib/systemd/system/${::zookeeper::service_name}.service":
         ensure  => 'present',
         content => template("${module_name}/zookeeper.service.erb"),
         } ~>

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -54,7 +54,7 @@ describe 'zookeeper::service' do
 
     it do
       should contain_file(
-        '/usr/lib/systemd/system/zookeeper.service'
+        '/usr/lib/systemd/system/zookeeper-server.service'
       ).with({
         'ensure' => 'present',
       })
@@ -65,6 +65,31 @@ describe 'zookeeper::service' do
         :ensure => 'running',
         :enable => true
       )
+    end
+
+    context 'custom service name' do
+      let :pre_condition do
+        'class {"zookeeper":
+           manage_service_file => true,
+           service_provider    => "systemd",
+           service_name        => "my-zookeeper",
+         }'
+      end
+
+        it do
+          should contain_file(
+            '/usr/lib/systemd/system/my-zookeeper.service'
+          ).with({
+            'ensure' => 'present',
+          })
+        end
+
+        it do
+          should contain_service('my-zookeeper').with(
+            :ensure => 'running',
+            :enable => true
+          )
+        end
     end
 
     context 'do not manage systemd' do


### PR DESCRIPTION
Systemd uses the service filename to look for the service name by default. 

This PR sets the service filename to the service name specified in `service_name` parameter and fixes some inconsistencies in RHEL unit tests.  