### PR TITLE
Fix service settings when installing from archive

### DIFF
--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -62,6 +62,7 @@ describe 'zookeeper::config' do
 
       it do
         is_expected.to contain_file('/etc/zookeeper/conf/environment').with_content(/ERROR/)
+        is_expected.to contain_file('/etc/zookeeper/conf/environment').with_content(/CLASSPATH/)
       end
 
       it do
@@ -81,6 +82,18 @@ describe 'zookeeper::config' do
         is_expected.to contain_file(
           '/etc/zookeeper/conf/zoo.cfg'
         ).with_content(/^#clientPortAddress=/)
+      end
+    end
+
+    context 'install from archive' do
+      let :pre_condition do
+        'class {"zookeeper":
+           install_method: "archive",
+           archive_version: "3.4.9",
+        }'
+
+        it {is_expected.to contain_file('/etc/zookeeper/conf/environment').without_content(/CLASSPATH/)}
+
       end
     end
 

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -61,6 +61,12 @@ describe 'zookeeper::service' do
     end
 
     it do
+      should contain_file(
+        '/usr/lib/systemd/system/zookeeper-server.service'
+      ).with_content(/zookeeper\.jar/)
+    end
+
+    it do
       should contain_service('zookeeper-server').with(
         :ensure => 'running',
         :enable => true
@@ -90,6 +96,24 @@ describe 'zookeeper::service' do
             :enable => true
           )
         end
+    end
+
+    context 'install from archive' do
+      let :pre_condition do
+        'class {"zookeeper":
+           manage_service_file => true,
+           service_provider    => "systemd",
+           install_method      => "archive",
+           archive_version     => "3.4.9"
+         }'
+      end
+
+      it do
+        should contain_file(
+          '/usr/lib/systemd/system/zookeeper-server.service'
+        ).with_content(/zookeeper-3\.4\.9\.jar/)
+      end
+
     end
 
     context 'do not manage systemd' do

--- a/templates/conf/environment.erb
+++ b/templates/conf/environment.erb
@@ -1,10 +1,12 @@
 NAME=zookeeper
 ZOOCFGDIR=<%= scope.lookupvar("zookeeper::cfg_dir") %>
 
+<% if scope.lookupvar('zookeeper::install_method') != 'archive' -%>
 # TODO this is really ugly
 # How to find out, which jars are needed?
 # seems, that log4j requires the log4j.properties file to be in the classpath
 CLASSPATH="$ZOOCFGDIR:/usr/share/java/jline.jar:/usr/share/java/log4j-1.2.jar:/usr/share/java/xercesImpl.jar:/usr/share/java/xmlParserAPIs.jar:/usr/share/java/netty.jar:/usr/share/java/slf4j-api.jar:/usr/share/java/slf4j-log4j12.jar:/usr/share/java/zookeeper.jar"
+<% end -%>
 
 #ZOOCFG="zoo.cfg"
 # necessary on Debian

--- a/templates/zookeeper.service.erb
+++ b/templates/zookeeper.service.erb
@@ -11,7 +11,12 @@ After=<%= scope.lookupvar("zookeeper::systemd_unit_after") %>
 <% end -%>
 
 [Service]
-ExecStart=/bin/sh -c 'set -x; . <%= scope.lookupvar("zookeeper::cfg_dir") %>/<%= scope.lookupvar("zookeeper::environment_file") %>; CLASSPATH="<%= @_zoo_dir %>/zookeeper.jar:<%= @_zoo_dir %>/lib/*:$CLASSPATH"; CLASSPATH="$(. <%= scope.lookupvar("zookeeper::service::_zoo_dir") %>/bin/zkEnv.sh ; echo $CLASSPATH)"; mkdir -p <%= scope.lookupvar("zookeeper::log_dir") %>; $JAVA "-Dzookeeper.log.dir=<%= scope.lookupvar("zookeeper::log_dir") %>" "-Dzookeeper.root.logger=$ZOO_LOG4J_PROP" -cp "$CLASSPATH" $JAVA_OPTS "$ZOOMAIN" "$ZOOCFG"'
+ExecStart=/bin/sh -c 'set -x; \
+  . <%= scope.lookupvar("zookeeper::cfg_dir") %>/<%= scope.lookupvar("zookeeper::environment_file") %>; \
+  CLASSPATH="<%= @_zoo_dir %>/zookeeper<% if scope.lookupvar('zookeeper::install_method') == 'archive' -%>-<%= scope.lookupvar("zookeeper::archive_version") %><% end -%>.jar:<%= @_zoo_dir %>/lib/*:$CLASSPATH"; \
+  CLASSPATH="$(. <%= scope.lookupvar("zookeeper::service::_zoo_dir") %>/bin/zkEnv.sh ; echo $CLASSPATH)"; \
+  mkdir -p <%= scope.lookupvar("zookeeper::log_dir") %>; \
+  $JAVA "-Dzookeeper.log.dir=<%= scope.lookupvar("zookeeper::log_dir") %>" "-Dzookeeper.root.logger=$ZOO_LOG4J_PROP" -cp "$CLASSPATH" $JAVA_OPTS "$ZOOMAIN" "$ZOOCFG"'
 Restart=always
 RemainAfterExit=no
 SyslogIdentifier=zookeeper


### PR DESCRIPTION
I found some issues when installing from archive and using the managed systemd service. Part of the configuration is generated for the CDH RPM and it is not valid when installing from tarball. 

1. In the environment file, the CLASSPATH uses the RPM references. In principle, it is not needed because the service file has already the right CLASSPATH. Maybe another option could be to leave the correct CLASSPATH in the environment file and remove the CLASSPATH from systemd? 
2. In the service file, the zookeeper jar file has the version number as suffix when installing from tarball (e.g. zookeeper-3.4.9.jar instead of zookeeper.jar)