### PR TITLE
Make service run even if bin/zkEnv.sh does not exist

### DIFF
--- a/templates/zookeeper.service.erb
+++ b/templates/zookeeper.service.erb
@@ -14,7 +14,7 @@ After=<%= scope.lookupvar("zookeeper::systemd_unit_after") %>
 ExecStart=/bin/sh -c 'set -x; \
   . <%= scope.lookupvar("zookeeper::cfg_dir") %>/<%= scope.lookupvar("zookeeper::environment_file") %>; \
   CLASSPATH="<%= @_zoo_dir %>/zookeeper<% if scope.lookupvar('zookeeper::install_method') == 'archive' -%>-<%= scope.lookupvar("zookeeper::archive_version") %><% end -%>.jar:<%= @_zoo_dir %>/lib/*:$CLASSPATH"; \
-  CLASSPATH="$(. <%= scope.lookupvar("zookeeper::service::_zoo_dir") %>/bin/zkEnv.sh ; echo $CLASSPATH)"; \
+  CLASSPATH="$([ -r <%= scope.lookupvar("zookeeper::service::_zoo_dir") %>/bin/zkEnv.sh ] && . <%= scope.lookupvar("zookeeper::service::_zoo_dir") %>/bin/zkEnv.sh ; echo $CLASSPATH)"; \
   mkdir -p <%= scope.lookupvar("zookeeper::log_dir") %>; \
   $JAVA "-Dzookeeper.log.dir=<%= scope.lookupvar("zookeeper::log_dir") %>" "-Dzookeeper.root.logger=$ZOO_LOG4J_PROP" -cp "$CLASSPATH" $JAVA_OPTS "$ZOOMAIN" "$ZOOCFG"'
 Restart=always


### PR DESCRIPTION
Some deployment of Zookeeper do not contain bin/zkEnv.sh and this make the service to fail when starting it.

The proposed change just check if file exist before executing it.