### PR TITLE
Provide option to remove host and realm from Kerberos principal

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,7 +81,9 @@ class zookeeper(
   $realm                   = $::zookeeper::params::realm,
   $store_key               = $::zookeeper::params::store_key,
   $use_keytab              = $::zookeeper::params::use_keytab,
-  $use_ticket_cache        = $::zookeeper::params::use_ticket_cache
+  $use_ticket_cache        = $::zookeeper::params::use_ticket_cache,
+  $remove_host_principal   = $::zookeeper::params::remove_host_principal,
+  $remove_realm_principal  = $::zookeeper::params::remove_realm_principal,
 ) inherits ::zookeeper::params {
 
   # validations are not necessary on Puppet 4
@@ -92,6 +94,8 @@ class zookeeper(
     validate_bool($initialize_datastore)
     validate_bool($manage_service)
     validate_bool($use_sasl_auth)
+    validate_bool($remove_host_principal)
+    validate_bool($remove_realm_principal)
     validate_hash($archive_checksum)
     validate_integer($id)
     validate_integer($init_limit)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -145,4 +145,6 @@ class zookeeper::params {
   $store_key = true
   $use_keytab = true
   $use_ticket_cache = false
+  $remove_host_principal = false
+  $remove_realm_principal = false
 }

--- a/spec/classes/sasl_spec.rb
+++ b/spec/classes/sasl_spec.rb
@@ -66,4 +66,40 @@ describe 'zookeeper::sasl' do
       ).with_content(/JAVA_OPTS="\${JAVA_OPTS} -Djava.security.auth.login.config=\/etc\/zookeeper\/conf\/jaas.conf"/)
     end
   end
+ 
+  context 'remove host and realm from principal' do
+    let(:facts) do
+      {
+      :operatingsystem => 'Debian',
+      :osfamily => 'Debian',
+      :operatingsystemmajrelease => '8',
+      :lsbdistcodename => 'jessie',
+      :puppetversion => Puppet.version,
+    }
+    end
+
+    let :pre_condition do
+      'class {"zookeeper":
+         use_sasl_auth => true,
+         remove_host_principal => true,
+         remove_realm_principal => true,
+       }'
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_class('zookeeper::sasl') }
+
+    it do
+      should contain_file(
+        '/etc/zookeeper/conf/zoo.cfg'
+      ).with_content(/kerberos.removeHostFromPrincipal=true/)
+    end
+   
+    it do
+      should contain_file(
+        '/etc/zookeeper/conf/zoo.cfg'
+      ).with_content(/kerberos.removeRealmFromPrincipal=true/)
+    end
+
+  end
 end

--- a/templates/conf/zoo.cfg.erb
+++ b/templates/conf/zoo.cfg.erb
@@ -121,4 +121,10 @@ maxSessionTimeout=<%= scope.lookupvar("zookeeper::max_session_timeout") %>
 # Enable SASL authentication and use the default provider/renew provided by cloudera
 authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
 jaasLoginRenew=3600000
+<% if scope.lookupvar("zookeeper::remove_host_principal") -%>
+kerberos.removeHostFromPrincipal=true
+<% end -%>
+<% if scope.lookupvar("zookeeper::remove_realm_principal") -%>
+kerberos.removeRealmFromPrincipal=true
+<% end -%>
 <% end -%>


### PR DESCRIPTION
Configuration will not change in case these flags are not set to true (default false).

If any of them is set, corresponding configuration parameters are set to true.