### PR TITLE
Fix Minor Version typo in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.5
+## 0.7.6
 - [Full diff](https://github.com/deric/puppet-zookeeper/compare/v0.7.5...v0.7.6)
 - Fixes:
   - [zookeeper does not start under debian stretch](https://github.com/deric/puppet-zookeeper/issues/109) #109


### PR DESCRIPTION
Small typo I noticed while browsing the change log today.

Thanks for contributing this module btw! 😃 