### PR TITLE
Replace sh with bash in systemd unit

### DIFF
--- a/templates/zookeeper.service.erb
+++ b/templates/zookeeper.service.erb
@@ -11,7 +11,7 @@ After=<%= scope.lookupvar("zookeeper::systemd_unit_after") %>
 <% end -%>
 
 [Service]
-ExecStart=/bin/sh -c 'set -x; \
+ExecStart=/bin/bash -c 'set -x; \
   . <%= scope.lookupvar("zookeeper::cfg_dir") %>/<%= scope.lookupvar("zookeeper::environment_file") %>; \
   CLASSPATH="<%= @_zoo_dir %>/zookeeper<% if scope.lookupvar('zookeeper::install_method') == 'archive' -%>-<%= scope.lookupvar("zookeeper::archive_version") %><% end -%>.jar:<%= @_zoo_dir %>/lib/*:$CLASSPATH"; \
   CLASSPATH="$([ -r <%= scope.lookupvar("zookeeper::service::_zoo_dir") %>/bin/zkEnv.sh ] && . <%= scope.lookupvar("zookeeper::service::_zoo_dir") %>/bin/zkEnv.sh ; echo $CLASSPATH)"; \


### PR DESCRIPTION
Since zookeeper v3.4.6 zkEnv.sh uses bash as a shebag. And moreover the script contains operations with arrays which sh (dash) doesn't support. Because of it systemd unit doesn't work and fails with following errors:
```
/bin/sh: 81: /opt/zookeeper-3.4.11/bin/zkEnv.sh: Syntax error: "(" unexpected (expecting "fi")
Error: Could not find or load main class org.apache.zookeeper.server.quorum.QuorumPeerMain
```
This patch replaces sh with bash in sytemd unit thereby fixes that problem.