### PR TITLE
Fix JAVA_OPTS broken with enabled sasl auth

### DIFF
--- a/spec/classes/sasl_spec.rb
+++ b/spec/classes/sasl_spec.rb
@@ -30,7 +30,7 @@ describe 'zookeeper::sasl' do
     it do
       is_expected.to contain_file(
         '/etc/zookeeper/conf/environment'
-      ).with_content(/JAVA_OPTS="\${JAVA_OPTS} -Djava.security.auth.login.config=\/etc\/zookeeper\/conf\/jaas.conf"/)
+      ).with_content(/JAVA_OPTS=".* -Djava.security.auth.login.config=\/etc\/zookeeper\/conf\/jaas.conf"/)
     end
   end
 
@@ -63,7 +63,7 @@ describe 'zookeeper::sasl' do
     it do
       is_expected.to contain_file(
         '/etc/zookeeper/conf/java.env'
-      ).with_content(/JAVA_OPTS="\${JAVA_OPTS} -Djava.security.auth.login.config=\/etc\/zookeeper\/conf\/jaas.conf"/)
+      ).with_content(/JAVA_OPTS=".* -Djava.security.auth.login.config=\/etc\/zookeeper\/conf\/jaas.conf"/)
     end
   end
  

--- a/templates/conf/environment.erb
+++ b/templates/conf/environment.erb
@@ -19,9 +19,10 @@ JAVA=<%= scope.lookupvar("zookeeper::java_bin") %>
 ZOOMAIN="<%= scope.lookupvar("zookeeper::zoo_main") %>"
 ZOO_LOG4J_PROP="<%= scope.lookupvar("zookeeper::log4j_prop") %>"
 JMXLOCALONLY=false
-JAVA_OPTS="<%= scope.lookupvar("zookeeper::java_opts") %>"
 <% if scope.lookupvar('zookeeper::use_sasl_auth') -%>
-JAVA_OPTS="${JAVA_OPTS} -Djava.security.auth.login.config=<%= File.join(scope.lookupvar("zookeeper::cfg_dir"), "jaas.conf") -%>"
+JAVA_OPTS="<%= scope.lookupvar("zookeeper::java_opts") %> -Djava.security.auth.login.config=<%= File.join(scope.lookupvar("zookeeper::cfg_dir"), "jaas.conf") -%>"
+<% else -%>
+JAVA_OPTS="<%= scope.lookupvar("zookeeper::java_opts") %>"
 <% end -%>
 # will be concatenated with JVMFLAGS var
 # see https://github.com/apache/zookeeper/blob/master/bin/zkServer.sh#L78


### PR DESCRIPTION
because variable expansion is not performed through systemd. [ref](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Environment=)

> Variable expansion is not performed inside the strings, [...]