### PR TITLE
Fix bug: prevent service from failing to log any upcoming events

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -51,6 +51,7 @@ class zookeeper::service inherits zookeeper {
   }
 
   if $::zookeeper::restart_on_change {
+    File[$::zookeeper::log_dir] ~> Service[$::zookeeper::service_name]
     File["${::zookeeper::cfg_dir}/myid"] ~> Service[$::zookeeper::service_name]
     File["${::zookeeper::cfg_dir}/zoo.cfg"] ~> Service[$::zookeeper::service_name]
     File["${::zookeeper::cfg_dir}/${::zookeeper::environment_file}"] ~> Service[$::zookeeper::service_name]


### PR DESCRIPTION
This commit adds a notiffer to zookeeper service whenever there is change to the log directory.

This pull request prevents a problematic situation where the service fails to log any upcoming events.

Specifically, if the log directory is removed from the host, we have to apply the catalog again in order to create a fresh directory.
However the service is unaffected from that change  and it still handles the file descriptor that corresponds to the original log file (note that during the start of the service, zookeeper opens the log file and keeps that file open for efficiency), i.e., the open file descriptor points to the inode which the initial log file pointed to.

When we remove an open file the underlying system call `unlink` does *not* affect the open file descriptors of the file.
In other words, any open file descriptor still refers to the inode of the removed file.
However, the inode becomes *orphaned* which means that is not linked with any file.
Therefore, in the case of a missing notifier, the log history of the upcoming events is lost because the service writes to an orphaned inode.