### PR TITLE
Update archive filename for version 3.5.5+ install

### DIFF
--- a/manifests/install/archive.pp
+++ b/manifests/install/archive.pp
@@ -4,7 +4,15 @@
 #
 # PRIVATE CLASS - do not use directly (use main `zookeeper` class).
 class zookeeper::install::archive inherits zookeeper::install {
-  $filename = "${module_name}-${::zookeeper::archive_version}"
+
+
+  # Apache updated the filename base for archive files in release 3.5.5
+  if versioncmp($::zookeeper::archive_version, '3.5.5') <= 0 {
+    $filename = "apache-${module_name}-${::zookeeper::archive_version}-bin"
+  } else {
+    $filename = "${module_name}-${::zookeeper::archive_version}"
+  }
+  
   $download_url = $::zookeeper::archive_dl_url ? {
     undef   => "${::zookeeper::archive_dl_site}/${module_name}-${::zookeeper::archive_version}/${filename}.tar.gz",
     default => $::zookeeper::archive_dl_url,

--- a/manifests/install/archive.pp
+++ b/manifests/install/archive.pp
@@ -7,7 +7,7 @@ class zookeeper::install::archive inherits zookeeper::install {
 
 
   # Apache updated the filename base for archive files in release 3.5.5
-  if versioncmp($::zookeeper::archive_version, '3.5.5') <= 0 {
+  if versioncmp($::zookeeper::archive_version, '3.5.5') >= 0 {
     $filename = "apache-${module_name}-${::zookeeper::archive_version}-bin"
   } else {
     $filename = "${module_name}-${::zookeeper::archive_version}"

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,7 +5,7 @@ class zookeeper::service inherits zookeeper {
 
   case $::zookeeper::install_method {
     'archive': {
-      $_zoo_dir = "${::zookeeper::archive_install_dir}/${module_name}-${::zookeeper::archive_version}"
+      $_zoo_dir = "${::zookeeper::archive_install_dir}/${module_name}"
     }
     'package': {
       $_zoo_dir = $::zookeeper::zoo_dir

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -327,11 +327,11 @@ describe 'zookeeper::install' do
     end
   end
 
-  context 'installing from tar archive' do
+  context 'installing 3.4.8 from tar archive' do
     let(:install_dir) { '/opt' }
     let(:zoo_dir) { '/opt/zookeeper' }
     let(:vers) { '3.4.8' }
-    let(:mirror_url) { 'http://apache.org/dist' }
+    let(:mirror_url) { 'http://archive.apache.org/dist' }
     let(:basefilename) { "zookeeper-#{vers}.tar.gz" }
     let(:package_url) { "#{mirror_url}/zookeeper/zookeeper-#{vers}/zookeeper-#{vers}.tar.gz" }
     let(:extract_path) { "#{zoo_dir}-#{vers}" }
@@ -359,6 +359,58 @@ describe 'zookeeper::install' do
         :target => extract_path,
       })
     end
+    it do
+      should contain_archive("#{install_dir}/#{basefilename}").with({
+        :extract_path => install_dir,
+        :source       => package_url,
+        :creates      => extract_path,
+        :user         => 'root',
+        :group        => 'root',
+      })
+    end
+
+    it do
+      is_expected.to contain_file('/etc/zookeeper').with({
+        :ensure => 'directory',
+        :owner => 'zookeeper',
+        :group => 'zookeeper',
+      })
+    end
+  end
+
+  context 'installing 3.5.5 from tar archive' do
+    let(:install_dir) { '/opt' }
+    let(:zoo_dir) { '/opt/zookeeper' }
+    let(:vers) { '3.5.5' }
+    let(:mirror_url) { 'http://apache.org/dist' }
+    let(:basefilename) { "apache-zookeeper-#{vers}.tar.gz" }
+    let(:package_url) { "#{mirror_url}/zookeeper/zookeeper-#{vers}/apache-zookeeper-#{vers}.tar.gz" }
+    let(:extract_path) { "#{zoo_dir}-#{vers}" }
+
+    let(:facts) {{
+      :operatingsystem => 'Ubuntu',
+      :osfamily => 'Debian',
+      :lsbdistcodename => 'trusty',
+      :operatingsystemmajrelease => '14.04',
+      :puppetversion => Puppet.version,
+    }}
+
+    let :pre_condition do
+      'class {"zookeeper":
+         install_method => "archive",
+         archive_version => "3.5.5",
+         archive_install_dir => "/opt",
+         zoo_dir => "/opt/zookeeper",
+       }'
+    end
+
+    it do
+      is_expected.to contain_file(zoo_dir).with({
+        :ensure => 'link',
+        :target => extract_path,
+      })
+    end
+
     it do
       should contain_archive("#{install_dir}/#{basefilename}").with({
         :extract_path => install_dir,


### PR DESCRIPTION
Apache updated the archive file name (apparently) starting with version 3.5.5 which was released last week. This effectively resolves the issue with a minor change, the `zoo_dir` variable is now pointed to the symlink location as opposed to the per-version directory. I found this to be the most direct way of fixing the issue whilst not refactoring a decent bit of code. I opened #129 regarding this issue and as promised, here's my proposed fix to the issue.

* update archive/tests

* update filename logic

* update zoo_path