### PR TITLE
Allow puppetlabs/stdlib 6.x, puppet/archive 4.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,11 +11,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 2.3.3 < 6.0.0"
+      "version_requirement": ">= 2.3.3 < 7.0.0"
     },
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 0.4.4 < 4.0.0"
+      "version_requirement": ">= 0.4.4 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This change is required for:
* https://github.com/voxpupuli/puppet-kafka
* https://travis-ci.org/voxpupuli/puppet-kafka/jobs/541735622

```
An error occurred while loading ./spec/acceptance/producer_spec.rb.
Failure/Error: install_module_dependencies_on(hosts)
Beaker::Host::CommandFailure:
  Host 'ubuntu1604-64-1' exited with 1 running:
   puppet module install deric-zookeeper -v 0.8.4
  Last 10 lines of output were:
  	Notice: Preparing to install into /etc/puppetlabs/code/environments/production/modules ...
  	Notice: Downloading from https://forgeapi.puppet.com ...
  	Error: Could not install module 'deric-zookeeper' (???)
  	  No version of 'deric-zookeeper' can satisfy all dependencies
  	    Use `puppet module install --ignore-dependencies` to install only this module
```