### PR TITLE
Change archive path for >= 3.5.5

### DIFF
--- a/manifests/install/archive.pp
+++ b/manifests/install/archive.pp
@@ -10,7 +10,7 @@ class zookeeper::install::archive inherits zookeeper::install {
   if versioncmp($::zookeeper::archive_version, '3.5.5') >= 0 {
     $filename = "apache-${module_name}-${::zookeeper::archive_version}-bin"
     $archive_dl_site = $::zookeeper::archive_dl_site ? {
-      undef   => 'http://apache.org/dist',
+      undef   => 'http://apache.org/dist/zookeeper',
       default => $::zookeeper::archive_dl_site,
     }
   } else {


### PR DESCRIPTION
After trying out the 0.8.5 release I still got the errors. I think this is the right path for downloading, at least this is working when setting the `archive_dl_site` manually.