### PR TITLE
Add admin server options from ZK 3.5.5

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -92,6 +92,11 @@ class zookeeper(
   Boolean                                    $use_ticket_cache        = $::zookeeper::params::use_ticket_cache,
   Boolean                                    $remove_host_principal   = $::zookeeper::params::remove_host_principal,
   Boolean                                    $remove_realm_principal  = $::zookeeper::params::remove_realm_principal,
+  Boolean                                    $admin_enable_server     = $::zookeeper::params::admin_enable_server,
+  String                                     $admin_server_address    = $::zookeeper::params::admin_server_address,
+  Integer                                    $admin_server_port       = $::zookeeper::params::admin_server_port,
+  Integer                                    $admin_idle_timeout      = $::zookeeper::params::admin_idle_timeout,
+  String                                     $admin_command_url       = $::zookeeper::params::admin_command_url,
 ) inherits ::zookeeper::params {
 
   if $pid_file {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -155,4 +155,11 @@ class zookeeper::params {
   $use_ticket_cache = false
   $remove_host_principal = false
   $remove_realm_principal = false
+
+  # admin server options
+  $admin_enable_server = true
+  $admin_server_address = '0.0.0.0'
+  $admin_server_port = 8080
+  $admin_idle_timeout = 30000
+  $admin_command_url = '/commands'
 }

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -87,6 +87,33 @@ describe 'zookeeper::config' do
       end
     end
 
+    context 'admin server options' do
+      enable = false
+      port = '3000'
+      url = '/alternative'
+      let :pre_condition do
+        "class {'zookeeper':
+           admin_enable_server => #{enable},
+           admin_server_port => #{port},
+           admin_command_url => '#{url}'
+         }"
+      end
+
+      it do
+        is_expected.to contain_file(
+          '/etc/zookeeper/conf/zoo.cfg'
+        ).with_content(/admin.enableServer=#{enable}/)
+
+        is_expected.to contain_file(
+          '/etc/zookeeper/conf/zoo.cfg'
+        ).with_content(/admin.serverPort=#{port}/)
+
+        is_expected.to contain_file(
+          '/etc/zookeeper/conf/zoo.cfg'
+        ).with_content(/admin.commandURL=#{url}/)
+      end
+    end
+
     context 'install from archive' do
       let :pre_condition do
         'class {"zookeeper":

--- a/templates/conf/zoo.cfg.erb
+++ b/templates/conf/zoo.cfg.erb
@@ -26,6 +26,17 @@ clientPortAddress=<%= scope.lookupvar("zookeeper::client_ip") %>
 #clientPortAddress=
 <% end -%>
 
+# Set to "false" to disable the AdminServer. By default the AdminServer is enabled.
+admin.enableServer=<%= scope.lookupvar('zookeeper::admin_enable_server') %>
+# The address the embedded Jetty server listens on. Defaults to 0.0.0.0.
+admin.serverAddress=<%= scope.lookupvar('zookeeper::admin_server_address') %>
+# The port the embedded Jetty server listens on. Defaults to 8080.
+admin.serverPort=<%= scope.lookupvar('zookeeper::admin_server_port') %>
+# Set the maximum idle time in milliseconds that a connection can wait before sending or receiving data. Defaults to 30000 ms.
+admin.idleTimeout=<%= scope.lookupvar('zookeeper::admin_idle_timeout') %>
+# The URL for listing and issuing commands relative to the root URL. Defaults to "/commands".
+admin.commandURL=<%= scope.lookupvar('zookeeper::admin_command_url') %>
+
 # specify all zookeeper servers
 # The first port is used by followers to connect to the leader
 # The second one is used for leader election


### PR DESCRIPTION
Added the admin server configuration options introduced in Zookeeper 3.5.0. See [3.5.5 documentation](https://zookeeper.apache.org/doc/r3.5.5/zookeeperAdmin.html) "AdminServer configuration" section for details.