### PR TITLE
allow configuring additional log appenders

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ have syslog listening on port 514/udp for this to work):
 
 ```puppet
 class { 'zookeeper':
-  log4j_prop      => 'INFO, SYSLOG',
+  log4j_prop      => 'INFO,SYSLOG',
   extra_appenders => {
     'Syslog' => {
       'class'                    => 'org.apache.log4j.net.SyslogAppender',

--- a/README.md
+++ b/README.md
@@ -209,6 +209,25 @@ Threshold supported values are: `ALL`, `DEBUG`, `ERROR`, `FATAL`, `INFO`, `OFF`,
 
 [MaxBackupIndex](https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/RollingFileAppender.html#maxBackupIndex)
 
+By default console, rolling file and trace logging can be configured. Additional log appenders (vulgo log methods) can be configured
+by adding a hash `extra_appenders`. The following sets up syslog logging and points the root logger towards syslog (note that you must
+have syslog listening on port 514/udp for this to work):
+
+```puppet
+class { 'zookeeper':
+  log4j_prop      => 'INFO, SYSLOG',
+  extra_appenders => {
+    'Syslog' => {
+      'class'                    => 'org.apache.log4j.net.SyslogAppender',
+      'layout'                   => 'org.apache.log4j.PatternLayout',
+      'layout.conversionPattern' => "${hostname} zookeeper[id:%X{myid}] - %-5p [%t:%C{1}@%L][%x] - %m%n",
+      'syslogHost'               => 'localhost',
+      'facility'                 => 'user',
+    },
+  },
+}
+```
+
 
 ## Hiera Support
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -95,6 +95,7 @@ class zookeeper(
   String                                     $rollingfile_threshold    = $::zookeeper::params::rollingfile_threshold,
   String                                     $tracefile_threshold      = $::zookeeper::params::tracefile_threshold,
   String                                     $console_threshold        = $::zookeeper::params::console_threshold,
+  Hash[String,Hash[String,String]]           $extra_appenders          = $::zookeeper::params::extra_appenders,
   # sasl options
   Hash[String, String]                       $sasl_users               = $::zookeeper::params::sasl_users,
   String                                     $keytab_path              = $::zookeeper::params::keytab_path,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -144,6 +144,7 @@ class zookeeper::params {
   $tracefile_threshold = 'TRACE'
   $maxfilesize = '256MB'
   $maxbackupindex = 20
+  $extra_appenders = {}
 
   # sasl options
   $sasl_krb5 = true

--- a/templates/conf/log4j.properties.erb
+++ b/templates/conf/log4j.properties.erb
@@ -65,9 +65,9 @@ log4j.appender.TRACEFILE.File=${zookeeper.tracelog.dir}/${zookeeper.tracelog.fil
 log4j.appender.TRACEFILE.layout=org.apache.log4j.PatternLayout
 ### Notice we are including log4j's NDC here (%x)
 log4j.appender.TRACEFILE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L][%x] - %m%n
-<% @extra_appenders.each_pair do |name, data| -%>
+<% @extra_appenders.sort.each_pair do |name, data| -%>
 
-<% data.each_pair do |key, value| -%>
+<% data.sort.each_pair do |key, value| -%>
 log4j.appender.<%= name.upcase %><% if key != 'class' %>.<%= key %><% end %>=<%= value %>
 <% end -%>
 <% end -%>

--- a/templates/conf/log4j.properties.erb
+++ b/templates/conf/log4j.properties.erb
@@ -65,3 +65,9 @@ log4j.appender.TRACEFILE.File=${zookeeper.tracelog.dir}/${zookeeper.tracelog.fil
 log4j.appender.TRACEFILE.layout=org.apache.log4j.PatternLayout
 ### Notice we are including log4j's NDC here (%x)
 log4j.appender.TRACEFILE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L][%x] - %m%n
+<% @extra_appenders.each_pair do |name, data| -%>
+
+<% data.each_pair do |key, value| -%>
+log4j.appender.<%= name.upcase %><% if key != 'class' %>.<%= key %><% end %>=<%= value %>
+<% end -%>
+<% end -%>

--- a/templates/conf/log4j.properties.erb
+++ b/templates/conf/log4j.properties.erb
@@ -65,9 +65,9 @@ log4j.appender.TRACEFILE.File=${zookeeper.tracelog.dir}/${zookeeper.tracelog.fil
 log4j.appender.TRACEFILE.layout=org.apache.log4j.PatternLayout
 ### Notice we are including log4j's NDC here (%x)
 log4j.appender.TRACEFILE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L][%x] - %m%n
-<% @extra_appenders.sort.each_pair do |name, data| -%>
+<% @extra_appenders.sort.map do |name, data| -%>
 
-<% data.sort.each_pair do |key, value| -%>
+<% data.sort.map do |key, value| -%>
 log4j.appender.<%= name.upcase %><% if key != 'class' %>.<%= key %><% end %>=<%= value %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
Add the ability to configure additional appenders in `log4j.properties`, useful e.g. for getting Zookeeper to log to syslog.