### PR TITLE
Support CentOS 8

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -84,7 +84,7 @@ class zookeeper::params {
   $java_bin = '/usr/bin/java'
   $java_opts = ''
   $java_package = undef
-  $repo = 'cloudera'
+  $repo = undef
   $proxy_server = undef
   $proxy_type = undef
 

--- a/metadata.json
+++ b/metadata.json
@@ -38,7 +38,8 @@
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {


### PR DESCRIPTION
Setting the default to "cloudera", makes it impossible to set to "undef"
on the class level. Therefore resetting the default back to undef.