### PR TITLE
add port_unification parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,6 +62,7 @@ class zookeeper(
   Optional[String]                           $client_ip                = $zookeeper::params::client_ip,
   Integer                                    $client_port              = $zookeeper::params::client_port,
   Optional[Integer]                          $secure_client_port       = $zookeeper::params::secure_client_port,
+  Optional[Boolean]                          $port_unification         = $zookeeper::params::port_unification,
   String                                     $datastore                = $zookeeper::params::datastore,
   Optional[String]                           $datalogstore             = $zookeeper::params::datalogstore,
   Integer                                    $election_port            = $zookeeper::params::election_port,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -126,6 +126,7 @@ class zookeeper::params {
   $client_ip = undef # use e.g. $::ipaddress if you want to bind to single interface
   $client_port = 2181
   $secure_client_port = undef
+  $port_unification = undef
   $datastore = '/var/lib/zookeeper'
   # datalogstore used to put transaction logs in separate location than snapshots
   $datalogstore = undef

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -544,6 +544,31 @@ shared_examples 'zookeeper common' do |os_facts|
         ).with_content(%r{globalOutstandingLimit=2000})
       end
     end
+    
+    context 'set portUnification' do
+      let :pre_condition do
+        'class {"zookeeper":
+           port_unification => true
+         }'
+      end
+
+      it do
+        is_expected.to contain_file(
+          '/etc/zookeeper/conf/zoo.cfg'
+        ).with_content(%r{portUnification=true})
+      end
+    end
+    context 'default does not set portUnification' do
+      let :pre_condition do
+        'class {"zookeeper":}'
+      end
+
+      it do
+        is_expected.not_to contain_file(
+          '/etc/zookeeper/conf/zoo.cfg'
+        ).with_content(%r{portUnification})
+      end
+    end
   end
 end
 

--- a/templates/conf/zoo.cfg.erb
+++ b/templates/conf/zoo.cfg.erb
@@ -34,6 +34,10 @@ secureClientPort=<%= scope.lookupvar("zookeeper::secure_client_port") %>
 <% else -%>
 #secureClientPort=2281
 <% end -%>
+# Supported since 3.5.5
+<% if ! [nil, :undefined, :undef].include?(scope.lookupvar("zookeeper::port_unification")) -%>
+portUnification=<%= scope.lookupvar("zookeeper::port_unification") %>
+<% end -%>
 
 # specify all zookeeper servers
 # The first port is used by followers to connect to the leader


### PR DESCRIPTION
This adds a parameter port_unification that sets the portUnification parameter in the config file.
This fixes https://github.com/deric/puppet-zookeeper/issues/158.