### PR TITLE
Move daemon-reload to restart_on_change

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -24,7 +24,6 @@ class zookeeper::service inherits zookeeper {
       ~> exec { 'systemctl daemon-reload # for zookeeper':
         refreshonly => true,
         path        => $::path,
-        notify      => Service[$zookeeper::service_name],
       }
     } elsif (
       $zookeeper::service_provider == 'init'
@@ -58,5 +57,6 @@ class zookeeper::service inherits zookeeper {
     File["${zookeeper::cfg_dir}/zoo.cfg"] ~> Service[$zookeeper::service_name]
     File["${zookeeper::cfg_dir}/${zookeeper::environment_file}"] ~> Service[$zookeeper::service_name]
     File["${zookeeper::cfg_dir}/log4j.properties"] ~> Service[$zookeeper::service_name]
+    Exec['systemctl daemon-reload # for zookeeper'] ~> Service[$::zookeeper::service_name]
   }
 }


### PR DESCRIPTION
Hi @deric , 
Change of ZK systemd file causing -> `systemctl daemon-reload` -> restart to ZK service.
If `$zookeeper::restart_on_change` configured to false, we don't need to restart the service.

Thank you, Yakir.