### PR TITLE
Add quorum_listen_on_all_ips option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,6 +86,7 @@ class zookeeper(
   Boolean                                    $use_sasl_auth            = $zookeeper::params::use_sasl_auth,
   String                                     $zoo_dir                  = $zookeeper::params::zoo_dir,
   String                                     $zoo_main                 = $zookeeper::params::zoo_main,
+  Boolean                                    $quorum_listen_on_all_ips = $zookeeper::params::quorum_listen_on_all_ips,
   # log4j properties
   String                                     $environment_file         = $zookeeper::params::environment_file,
   String                                     $log4j_prop               = $zookeeper::params::log4j_prop,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -126,6 +126,7 @@ class zookeeper::params {
   $client_ip = undef # use e.g. $::ipaddress if you want to bind to single interface
   $client_port = 2181
   $secure_client_port = undef
+  $quorum_listen_on_all_ips = false
   $datastore = '/var/lib/zookeeper'
   # datalogstore used to put transaction logs in separate location than snapshots
   $datalogstore = undef

--- a/templates/conf/environment.erb
+++ b/templates/conf/environment.erb
@@ -1,7 +1,10 @@
 NAME=zookeeper
 ZOOCFGDIR=<%= scope.lookupvar("zookeeper::cfg_dir") %>
 
-<% if scope.lookupvar('zookeeper::install_method') != 'archive' and scope.lookupvar('zookeeper::service_provider') != 'systemd' -%>
+<% if scope.lookupvar('zookeeper::install_method') != 'archive' and 
+  (scope.lookupvar('zookeeper::service_provider') != 'systemd' or
+     (scope.lookupvar('zookeeper::service_provider') == 'systemd' and !scope.lookupvar('zookeeper::manage_service_file'))
+  )-%>
 # TODO this is really ugly
 # How to find out, which jars are needed?
 # seems, that log4j requires the log4j.properties file to be in the classpath

--- a/templates/conf/zoo.cfg.erb
+++ b/templates/conf/zoo.cfg.erb
@@ -59,6 +59,9 @@ secureClientPort=<%= scope.lookupvar("zookeeper::secure_client_port") %>
 <%= "server.#{id}=#{host}:%s:%s%s" % [scope.lookupvar("zookeeper::election_port"), scope.lookupvar("zookeeper::leader_port"), observer_text ] %>
 <%- end -%>
 
+# Bind election_port and leader_port to all interfaces (0.0.0.0)
+quorumListenOnAllIPs=<%= scope.lookupvar("zookeeper::quorum_listen_on_all_ips") %>
+
 # To avoid seeks ZooKeeper allocates space in the transaction log file in
 # blocks of preAllocSize kilobytes. The default block size is 64M. One reason
 # for changing the size of the blocks is to reduce the block size if snapshots


### PR DESCRIPTION
This PR adds the option `quorumListenOnAllIPs` to `zoo.cfg` configuration file. By default, Zookeeper binds to the IP resolved using servers array DNS resolution, in some cases might be 127.0.0.1 or 127.0.1.1 if it uses /etc/hosts, which might not work in some scenarios. Using `quorumListenOnAllIPs`, zookeeper binds to `0.0.0.0`.

The PR also restores the `CLASSPATH` setting in `environment` config file in case that `systemd` is used but it's not being managed by the module itself. This has been tested on a fresh Debian 10 installation and zookeeper version `3.4.13-2` (standard debian 10 package).
