### PR TITLE
Change default archive url

### DIFF
--- a/manifests/install/archive.pp
+++ b/manifests/install/archive.pp
@@ -8,7 +8,7 @@ class zookeeper::install::archive inherits zookeeper::install {
   if versioncmp($zookeeper::archive_version, '3.5.5') >= 0 {
     $filename = "apache-${module_name}-${zookeeper::archive_version}-bin"
     $archive_dl_site = $zookeeper::archive_dl_site ? {
-      undef   => 'http://apache.org/dist/zookeeper',
+      undef   => 'https://downloads.apache.org/zookeeper',
       default => $zookeeper::archive_dl_site,
     }
   } else {

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -257,7 +257,7 @@ shared_examples 'zookeeper install' do |os_facts|
     let(:install_dir) { '/opt' }
     let(:zoo_dir) { '/opt/zookeeper' }
     let(:vers) { '3.5.5' }
-    let(:mirror_url) { 'http://apache.org/dist/zookeeper' }
+    let(:mirror_url) { 'https://downloads.apache.org/zookeeper' }
     let(:basefilename) { "apache-zookeeper-#{vers}-bin.tar.gz" }
     let(:package_url) { "#{mirror_url}/zookeeper-#{vers}/apache-zookeeper-#{vers}-bin.tar.gz" }
     let(:extract_path) { "/opt/apache-zookeeper-#{vers}-bin" }


### PR DESCRIPTION
Apache has moved non-archive versions to a new location
```
$ curl http://apache.org/dist/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>302 Found</title>
</head><body>
<h1>Found</h1>
<p>The document has moved <a href="https://downloads.apache.org/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz">here</a>.</p>
</body></html>
```

Archive versions stayed in their place. 