### PR TITLE
Get rid of validate_string due to deprecation

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,8 +14,6 @@ class zookeeper::install inherits zookeeper {
       fail('Java installation is required, but no java package was provided.')
     }
 
-    validate_string($zookeeper::java_package)
-
     # Make sure the Java package is only installed once.
     anchor { 'zookeeper::install::java': }
 


### PR DESCRIPTION
Get rid of deprecated `validate_string`. (Parameter was typed earlier). 