### PR TITLE
Add support for Rocky Linux 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ rake beaker:sets
 ## Supported platforms
 
   * Debian/Ubuntu
-  * RedHat/CentOS/Fedora
+  * RedHat/CentOS/Fedora/Rocky
 
 ### Tested on:
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,7 +32,7 @@ class zookeeper::params {
     }
     'RedHat': {
       case $os_name {
-        'RedHat', 'CentOS': {
+        'RedHat', 'CentOS', 'Rocky': {
           if versioncmp($os_release, '7') < 0 {
             $initstyle = 'redhat'
           } else {

--- a/metadata.json
+++ b/metadata.json
@@ -42,6 +42,12 @@
       ]
     },
     {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8"
+      ]
+    },
+    {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "8",


### PR DESCRIPTION
Hello,
it's a naive modification to support Rocky Linux (main RHEL clone since CentOS) in version 8.