### PR TITLE
fixes #187 ssl ciphersuites is optional, and removed when not set

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -134,7 +134,7 @@ class zookeeper::params {
   $secure_port_only = false
   $ssl = false
   $ssl_protocol = 'TLSv1.2'
-  $ssl_ciphersuites = ''
+  $ssl_ciphersuites = undef
   $ssl_hostname_verification = true
   $ssl_clientauth = 'none'
   $keystore_location = "/etc/zookeeper/conf/keystores/${facts['networking']['fqdn']}.pem"
@@ -149,7 +149,7 @@ class zookeeper::params {
   $truststore_quorum_location = '/etc/ssl/certs/ca-certificates.crt'
   $truststore_quorum_password = undef
   $truststore_quorum_type = 'PEM'
-  $ssl_quorum_ciphersuites = ''
+  $ssl_quorum_ciphersuites = undef
   $ssl_quorum_hostname_verification = true
   $ssl_quorum_protocol = 'TLSv1.2'
   $ssl_quorum = false

--- a/templates/conf/zoo.cfg.erb
+++ b/templates/conf/zoo.cfg.erb
@@ -178,9 +178,11 @@ ssl.trustStore.type=<%= scope.lookupvar("zookeeper::truststore_type") %>
 <% if scope.lookupvar("zookeeper::truststore_password") %>
 ssl.trustStore.password=<%= scope.lookupvar("zookeeper::truststore_password") %>
 <% end -%>
-<% if scope.lookupvar("zookeeper::ssl_ciphersuites") %>
 # Set allowed Ciphers
+<% if ! [nil, :undefined, :undef].include?scope.lookupvar("zookeeper::ssl_ciphersuites") %>
 ssl.ciphersuites=<%= scope.lookupvar("zookeeper::ssl_ciphersuites") %>
+<% else -%>
+#ssl.ciphersuites=
 <% end -%>
 
 # Server TLS configuration
@@ -208,9 +210,11 @@ ssl.quorum.trustStore.location=<%= scope.lookupvar("zookeeper::truststore_quorum
 ssl.quorum.trustStore.password=<%= scope.lookupvar("zookeeper::truststore_quorum_password") %>
 <% end -%>
 
-<% if scope.lookupvar("zookeeper::ssl_quorum_ciphersuites") %>
 # Set allowed Ciphers
+<% if ! [nil, :undefined, :undef].include?scope.lookupvar("zookeeper::ssl_quorum_ciphersuites") %>
 ssl.quorum.ciphersuites=<%=scope.lookupvar("zookeeper::ssl_quorum_ciphersuites") %>
+<% else -%>
+#ssl.quorum.ciphersuites=
 <% end -%>
 <% end -%>
 


### PR DESCRIPTION
This commit will make `$ssl_ciphersuites` and `$ssl_quorum_ciphersuites` optional and will not define them in zoo.cfg

Previously a none supplied ciphersuite would defined the following in zoo.cfg leading to the following Exception `Exception in thread "QuorumConnectionThread-[myid=1]-72" java.lang.IllegalArgumentException: The specified CipherSuites array contains invalid null or empty string elements`
```
ssl.ciphersuites=
```
Fix for issue: https://github.com/deric/puppet-zookeeper/issues/187