### PR TITLE
SASL Digest-MD5 for the ZK Quorum

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -136,6 +136,12 @@ class zookeeper (
   Boolean                                    $use_ticket_cache                 = $zookeeper::params::use_ticket_cache,
   Boolean                                    $remove_host_principal            = $zookeeper::params::remove_host_principal,
   Boolean                                    $remove_realm_principal           = $zookeeper::params::remove_realm_principal,
+  # Quorum SASL /!\ Only works with ZK 3.4.10 or more recent; disabled by default /!\
+  Boolean                                    $quorum_auth_enable_sasl          = $zookeeper::params::quorum_auth_enable_sasl,
+  Boolean                                    $quorum_auth_learner_require_sasl = $zookeeper::params::quorum_auth_learner_require_sasl,
+  Boolean                                    $quorum_auth_server_require_sasl  = $zookeeper::params::quorum_auth_server_require_sasl,
+  String                                     $quorum_sasl_user                 = $zookeeper::params::quorum_sasl_user,
+  String                                     $quorum_sasl_password             = $zookeeper::params::quorum_sasl_password,
   # four letter words whitelist
   Array[String]                              $whitelist_4lw                    = $zookeeper::params::whitelist_4lw,
   # Metrics Providers

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -210,6 +210,13 @@ class zookeeper::params {
   # whitelist of Four Letter Words commands, see https://zookeeper.apache.org/doc/r3.4.12/zookeeperAdmin.html#sc_zkCommands
   $whitelist_4lw = []
 
+  # quorum SASL
+  $quorum_auth_enable_sasl = false
+  $quorum_auth_learner_require_sasl = false
+  $quorum_auth_server_require_sasl = false
+  $quorum_sasl_user = undef
+  $quorum_sasl_password = undef
+
   # Metrics Providers
   $metrics_provider_classname = undef
   $metrics_provider_http_port = 7000

--- a/templates/conf/jaas.conf.erb
+++ b/templates/conf/jaas.conf.erb
@@ -13,3 +13,17 @@ Server {
     <% end %>;
 <% end -%>
 };
+
+<% if scope.lookupvar("zookeeper::quorum_auth_enable_sasl") -%>
+<%# Only tested with Digest-MD5 authentication scheme but it can also work with Kerberos -%>
+QuorumServer {
+       org.apache.zookeeper.server.auth.DigestLoginModule required
+       user_<%= scope.lookupvar("zookeeper::quorum_sasl_user") %>="<%= scope.lookupvar("zookeeper::quorum_sasl_password") %>";
+};
+
+QuorumLearner {
+       org.apache.zookeeper.server.auth.DigestLoginModule required
+       username="<%= scope.lookupvar("zookeeper::quorum_sasl_user") %>"
+       password="<%= scope.lookupvar("zookeeper::quorum_sasl_password") %>";
+};
+<% end -%>

--- a/templates/conf/zoo.cfg.erb
+++ b/templates/conf/zoo.cfg.erb
@@ -142,6 +142,16 @@ kerberos.removeRealmFromPrincipal=true
 <% end -%>
 <% end -%>
 
+<% if scope.lookupvar("zookeeper::quorum_auth_enable_sasl") -%>
+quorum.auth.enableSasl=true
+<% end -%>
+<% if scope.lookupvar("zookeeper::quorum_auth_learner_require_sasl") -%>
+quorum.auth.learnerRequireSasl=true
+<% end -%>
+<% if scope.lookupvar("zookeeper::quorum_auth_server_require_sasl") -%>
+quorum.auth.serverRequireSasl=true
+<% end -%>
+
 <% if scope.lookupvar("zookeeper::ssl") -%>
 # Supported since 3.5.1
 <% if ! [nil, :undefined, :undef].include?(scope.lookupvar("zookeeper::secure_client_port")) -%>


### PR DESCRIPTION
Hi !

Since ZK 3.4.10, we can have SASL authentication for the quorum (more information here : https://cwiki.apache.org/confluence/display/ZOOKEEPER/Server-Server+mutual+authentication). This PR implements SASL for server2server authentication using Digest-MD5 but can be improved to include Kerberos (I don't have Kerberos in my testing environment) :)