### PR TITLE
Fix Warning with updated Stdlib

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -75,7 +75,7 @@ class zookeeper::params {
       fail("Module '${module_name}' is not supported on OS: '${os_name}', family: '${os_family}'")
     }
   }
-  $_params = merge($_defaults, $_os_overrides)
+  $_params = stdlib::merge($_defaults, $_os_overrides)
 
   # meta options
   $ensure = present

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 2.3.3 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/yumrepo_core",


### PR DESCRIPTION
Fix Warning ”This function is deprecated, please use stdlib::merge instead.”