### PR TITLE
add possibility to logrotate timebased instead on filesize. 

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -128,6 +128,9 @@
 # @param audit_threshold
 # @param audit_maxfilesize
 # @param audit_maxbackupindex
+# @param logrotate_days
+# @param $logrotate_timebased
+
 # @param sasl_users
 # @param keytab_path
 # @param principal
@@ -261,6 +264,9 @@ class zookeeper (
   String                                     $audit_threshold                  = $zookeeper::params::audit_threshold,
   String                                     $audit_maxfilesize                = $zookeeper::params::audit_maxfilesize,
   String                                     $audit_maxbackupindex             = $zookeeper::params::audit_maxbackupindex,
+  Integer                                    $logrotate_days                   = $zookeeper::params::logrotate_days,
+  Boolean                                    $logrotate_timebased              = $zookeeper::params::logrotate_timebased, 
+
   # sasl options
   Hash[String, String]                       $sasl_users                       = $zookeeper::params::sasl_users,
   String                                     $keytab_path                      = $zookeeper::params::keytab_path,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -199,6 +199,8 @@ class zookeeper::params {
   $audit_threshold = 'INFO'
   $audit_maxfilesize = '10M'
   $audit_maxbackupindex = '10'
+  $logrotate_days = 7
+  $logrotate_timebased = false
 
   # sasl options
   $sasl_krb5 = true

--- a/templates/conf/logback.xml.erb
+++ b/templates/conf/logback.xml.erb
@@ -29,6 +29,7 @@
   <property name="zookeeper.log.file" value="zookeeper.log" />
   <property name="zookeeper.log.threshold" value="<%= scope.lookupvar("zookeeper::rollingfile_threshold") %>" />
   <property name="zookeeper.log.maxfilesize" value="<%= scope.lookupvar("zookeeper::maxfilesize") %>" />
+  <property name="zookeeper.log.days" value="<%= scope.lookupvar("zookeeper::logrotate_days") %>" />
   <property name="zookeeper.log.maxbackupindex" value="<%= scope.lookupvar("zookeeper::maxbackupindex") %>" />
 
   <!--
@@ -52,6 +53,12 @@
     <encoder>
       <pattern>%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n</pattern>
     </encoder>
+<% if @logrotate_timebased -%>
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <maxHistory>${zookeeper.log.days}</maxHistory>
+      <FileNamePattern>${zookeeper.log.dir}/${zookeeper.log.file}-%d{yyyy-MM-dd}</FileNamePattern>
+    </rollingPolicy>
+<% else -%>
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
       <level>${zookeeper.log.threshold}</level>
     </filter>
@@ -62,6 +69,7 @@
     <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
       <MaxFileSize>${zookeeper.log.maxfilesize}</MaxFileSize>
     </triggeringPolicy>
+<% end -%>
   </appender>
 
   <!--


### PR DESCRIPTION
at the moment the logfiles will only rotated after (per default) 256M.
In most cases, the user want to rotate daily. This implements the options to configure timebased logrotation if wanted.