### PR TITLE
Fix issue with maxfilesize metric convention showing error with zk commands

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -197,7 +197,7 @@ class zookeeper::params {
   $maxbackupindex = 20
   $extra_appenders = {}
   $audit_threshold = 'INFO'
-  $audit_maxfilesize = '10M'
+  $audit_maxfilesize = '10MB'
   $audit_maxbackupindex = '10'
   $logrotate_days = 7
   $logrotate_timebased = false


### PR DESCRIPTION
This solves issues like this when we don't overwrite the default audit_maxfilesize value when audit logs are enabled in the module:
`
$ zookeeper-client
(...)
16:40:52,003 |-ERROR in ch.qos.logback.core.joran.util.PropertySetter@3d921e20 - Failed to invoke valueOf{} method in class [ch.qos.logback.core.util.FileSize] with value [10M]
16:40:52,004 |-WARN in ch.qos.logback.core.joran.util.PropertySetter@3d921e20 - Failed to set property [MaxFileSize] to value "10M".  ch.qos.logback.core.util.PropertySetterException: Conversion to type [class ch.qos.logback.core.util.FileSize] failed.
	at ch.qos.logback.core.util.PropertySetterException: Conversion to type [class ch.qos.logback.core.util.FileSize] failed.
`