### PR TITLE
Support setting Java home (closes #203)

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -83,6 +83,7 @@ The following parameters are available in the `zookeeper` class:
 * [`java_bin`](#-zookeeper--java_bin)
 * [`java_opts`](#-zookeeper--java_opts)
 * [`java_package`](#-zookeeper--java_package)
+* [`java_home`](#-zookeeper--java_home)
 * [`repo`](#-zookeeper--repo)
 * [`manage_service`](#-zookeeper--manage_service)
 * [`manage_service_file`](#-zookeeper--manage_service_file)
@@ -602,6 +603,14 @@ Data type: `Optional[String]`
 
 
 Default value: `$zookeeper::params::java_package`
+
+##### <a name="-zookeeper--java_home"></a>`java_home`
+
+Data type: `Optional[String]`
+
+
+
+Default value: `undef`
 
 ##### <a name="-zookeeper--repo"></a>`repo`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,8 @@
 # @param install_java
 # @param install_method
 # @param java_bin
+# @param java_home
+#   Sets JAVA_HOME, if defined
 # @param java_opts
 # @param java_package
 # @param repo
@@ -180,6 +182,7 @@ class zookeeper (
   String                                     $java_bin                         = $zookeeper::params::java_bin,
   String                                     $java_opts                        = $zookeeper::params::java_opts,
   Optional[String]                           $java_package                     = $zookeeper::params::java_package,
+  Optional[String]                           $java_home                        = undef,
   Optional[Hash]                             $repo                             = $zookeeper::params::repo,
   # service options
   Boolean                                    $manage_service                   = $zookeeper::params::manage_service,

--- a/manifests/install/package.pp
+++ b/manifests/install/package.pp
@@ -10,7 +10,7 @@ class zookeeper::install::package inherits zookeeper::install {
   # Make sure, that service package was not installed earlier
   if ($zookeeper::service_provider == 'init.d' and (!member($zookeeper::packages, $zookeeper::service_package))) {
     package { [$zookeeper::service_package]: #init.d scripts for zookeeper
-      ensure  => $zookeeper::ensure,
+      ensure => $zookeeper::ensure,
     }
   }
 }

--- a/manifests/post_install.pp
+++ b/manifests/post_install.pp
@@ -73,11 +73,11 @@ class zookeeper::post_install inherits zookeeper {
       }
 
       cron::job { 'zookeeper-cleanup':
-        ensure  => $zookeeper::ensure,
+        ensure => $zookeeper::ensure,
       }
     } else {
       file { '/etc/cron.daily/zkcleanup':
-        ensure  => $zookeeper::ensure,
+        ensure => $zookeeper::ensure,
       }
     }
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -227,6 +227,20 @@ describe 'zookeeper', type: :class do
     end
   end
 
+  context 'with java_home' do
+    let(:params) do
+      {
+        java_home: '/usr/lib/jvm/java-21',
+      }
+    end
+
+    it {
+      is_expected.to contain_file(
+        environment_file,
+      ).with_content(%r{JAVA_HOME="\/usr\/lib\/jvm\/java-21"})
+    }
+  end
+
   context 'managed by exhibitor' do
     let(:params) do
       {

--- a/templates/conf/environment.erb
+++ b/templates/conf/environment.erb
@@ -1,6 +1,8 @@
 NAME=zookeeper
 ZOOCFGDIR=<%= scope.lookupvar("zookeeper::cfg_dir") %>
-
+<% if scope.lookupvar("zookeeper::java_bin") -%>
+JAVA_HOME="<%= scope.lookupvar("zookeeper::java_home") %>"
+<% end -%>
 <% if scope.lookupvar('zookeeper::install_method') != 'archive' and
   (scope.lookupvar('zookeeper::service_provider') != 'systemd' or
      (scope.lookupvar('zookeeper::service_provider') == 'systemd' and !scope.lookupvar('zookeeper::manage_service_file'))


### PR DESCRIPTION
When `zookeeper::java_home` is set, corresponding value will be set to `JAVA_HOME` env var.