### PR TITLE
Bump yumrepo_core dep to 4.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs/yumrepo_core",
-      "version_requirement": ">= 1.0.3 < 3.0.0"
+      "version_requirement": ">= 1.0.3 < 4.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
3.0.1 is out and is fully compatible with this module.